### PR TITLE
Include release.yml in publishable changes check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,7 @@ jobs:
             'package-lock.json' \
             'tsconfig.json' \
             '.changeset/**' \
+            '.github/workflows/release.yml' \
           )
           if [ -n "$CHANGED" ]; then
             echo "has_changes=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Including `release.yml` in the check for publishable changes ensures that updates to the workflow file are recognized during the release process.