### PR TITLE
ci: use app token for catalog refresh workflow

### DIFF
--- a/.github/workflows/refresh-catalog.yml
+++ b/.github/workflows/refresh-catalog.yml
@@ -50,22 +50,29 @@ jobs:
             echo "Model catalog has changed"
           fi
 
-      - name: Open PR with version bump
+      - name: Generate app token
+        if: steps.diff.outputs.changed == 'true'
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Open PR with catalog update
         if: steps.diff.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          # Bump patch version in package.json and sync package-lock.json
-          npm version patch --no-git-tag-version
-          npm install --package-lock-only
+          # Use app token for push so CI triggers on the PR
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
 
           # Create branch and commit
           BRANCH="chore/catalog-refresh-$(date +%Y%m%d%H%M)"
           git checkout -b "$BRANCH"
-          git add src/modelCatalog.generated.json package.json package-lock.json
+          git add src/modelCatalog.generated.json
           git commit -m "chore: refresh model catalog"
           git push origin "$BRANCH"
 


### PR DESCRIPTION
- Replace GITHUB_TOKEN with app-generated token for PR creation
- Add step to generate GitHub App token using app credentials
- Remove version bumping logic (npm version patch and package-lock sync)
- Simplify git add to only include model catalog file
- Configure git remote with app token for proper CI trigger on PR
- Rename step from "Open PR with version bump" to "Open PR with catalog update"
- Ensures catalog refresh PRs trigger CI workflows with proper authentication