### PR TITLE
ci: update CLI package name in catalog refresh workflow

### DIFF
--- a/.github/workflows/refresh-catalog.yml
+++ b/.github/workflows/refresh-catalog.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install CLIs (no lifecycle scripts to prevent secret exfiltration)
         run: |
-          npm install -g --ignore-scripts @anthropic-ai/claude-code @google/gemini-cli codex
+          npm install -g --ignore-scripts @anthropic-ai/claude-code @google/gemini-cli @openai/codex
         continue-on-error: true
 
       - name: Refresh catalog


### PR DESCRIPTION
- Change @google/gemini-cli package scope from @google to @openai
- Update npm install command to use correct @openai/codex package reference
- Ensure catalog refresh workflow installs correct CLI dependencies