### PR TITLE
feat: bash discovery + CLI enrichment for model catalog refresh

### DIFF
--- a/scripts/extract-claude.sh
+++ b/scripts/extract-claude.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+exec 2>/dev/null
+
+# Use a unique temporary directory
+TMP_DIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'claude-extract')
+
+# Function to clean up on exit
+cleanup() {
+    rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+cd "$TMP_DIR" || { echo '{}'; exit 0; }
+
+TARBALL=$(npm pack @anthropic-ai/claude-code@latest) || { echo '{}'; exit 0; }
+tar -xzf "$TARBALL" || { echo '{}'; exit 0; }
+
+RESULT=$(grep 'OPUS_ID.*OPUS_NAME.*SONNET_ID.*SONNET_NAME' ./package/cli.js | \
+  grep -o '{OPUS_ID:"[^"]*",OPUS_NAME:"[^"]*",SONNET_ID:"[^"]*",SONNET_NAME:"[^"]*"[^}]*}' | \
+  sed 's/\([A-Z_]*\):/"\1":/g' | \
+  jq -c '[to_entries[] | select(.key | endswith("_ID")) | .value] | unique') || { echo '[]'; exit 0; }
+
+echo "${RESULT:-[]}"

--- a/scripts/extract-codex.sh
+++ b/scripts/extract-codex.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# extract-codex.sh - Extract model identifiers from the Codex repository.
+
+# Use a unique temporary directory
+TMP_DIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'codex-extract')
+REPO_URL="${CODEX_REPO_URL:-https://github.com/openai/codex}"
+MODELS_FILE="codex-rs/core/models.json"
+
+# Function to clean up on exit
+cleanup() {
+    rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+# 1. Shallow clone with no checkout for efficiency
+if ! git clone --quiet --depth 1 --no-checkout --filter=blob:none "$REPO_URL" "$TMP_DIR" > /dev/null 2>&1; then
+    echo "[]"
+    exit 0
+fi
+
+cd "$TMP_DIR" || { echo "[]"; exit 0; }
+
+# 2. Attempt to checkout the models file from main
+if ! git checkout main -- "$MODELS_FILE" > /dev/null 2>&1; then
+    # Fallback to master if main failed
+    if ! git checkout master -- "$MODELS_FILE" > /dev/null 2>&1; then
+        echo "[]"
+        exit 0
+    fi
+fi
+
+# 3. Extract slugs using jq and output as a JSON array to stdout
+if [ -f "$MODELS_FILE" ]; then
+    RESULT=$(jq -c '[.models[].slug | select(contains("oss") | not)] | unique' "$MODELS_FILE")
+else
+    RESULT="[]"
+fi
+
+echo "${RESULT:-[]}"

--- a/scripts/extract-gemini.sh
+++ b/scripts/extract-gemini.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# extract-gemini.sh
+# Replicates the "I'm offline" model discovery logic for Gemini CLI.
+# Programmatically determines the version of @google/gemini-cli on npm and
+# fetches the model definitions from the corresponding Git tag.
+
+# Use a unique temporary directory to avoid conflicts
+TMP_ROOT=$(mktemp -d)
+TMP_DIR="$TMP_ROOT/gemini-cli"
+REPO_URL="https://github.com/google-gemini/gemini-cli.git"
+TARGET_FILE="packages/core/src/config/models.ts"
+
+# Function to clean up on exit
+cleanup() {
+    rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+# 1. Determine the target version/tag from npm
+NPM_VERSION=$(npm view @google/gemini-cli version 2>/dev/null)
+TARGET_REF="main"
+
+if [ -n "$NPM_VERSION" ]; then
+    # Tags follow the pattern vX.Y.Z
+    POSSIBLE_TAG="v$NPM_VERSION"
+    
+    # Verify the tag exists without fully cloning
+    if git ls-remote --tags --exit-code "$REPO_URL" "$POSSIBLE_TAG" > /dev/null 2>&1; then
+        TARGET_REF="$POSSIBLE_TAG"
+    fi
+fi
+
+# 2. Clone the specific target ref (branch or tag)
+if ! git clone --quiet --depth 1 --branch "$TARGET_REF" --filter=blob:none --no-checkout "$REPO_URL" "$TMP_DIR" >/dev/null 2>&1; then
+    TARGET_REF="main"
+    if ! git clone --quiet --depth 1 --branch "$TARGET_REF" --filter=blob:none --no-checkout "$REPO_URL" "$TMP_DIR" >/dev/null 2>&1; then
+        TARGET_REF="master"
+        git clone --quiet --depth 1 --branch "$TARGET_REF" --filter=blob:none --no-checkout "$REPO_URL" "$TMP_DIR" >/dev/null 2>&1 || { echo '[]'; exit 0; }
+    fi
+fi
+cd "$TMP_DIR" || { echo '[]'; exit 0; }
+
+# 3. Checkout only the target file
+if ! git checkout "$TARGET_REF" -- "$TARGET_FILE" >/dev/null 2>&1; then
+    echo "[]"
+    exit 0
+fi
+
+# 4. Extract model IDs into a JSON array
+# Finds strings starting with 'gemini-' inside single quotes, 
+# ensuring they represent complete model names and excluding the embedding model.
+if [ -f "$TARGET_FILE" ]; then
+    RESULT=$(grep -oE "'gemini-[^']+'" "$TARGET_FILE" | \
+      sed "s/'//g" | \
+      grep -v "embedding" | \
+      grep -v "custom" | \
+      grep -vE "^gemini-[0-9.]+-$" | \
+      grep -vE "^gemini-[0-9.]+$" | \
+      sort -u | \
+      jq -cR . | jq -cs .)
+else
+    RESULT="[]"
+fi
+
+# 5. Output the result
+echo "${RESULT:-[]}"

--- a/scripts/refresh-catalog.ts
+++ b/scripts/refresh-catalog.ts
@@ -2,8 +2,12 @@
 /**
  * refresh-catalog.ts
  *
- * Queries each CLI (claude, gemini, codex) to self-report available models,
- * then writes src/modelCatalog.generated.json.
+ * 5-phase model catalog refresh:
+ *   1. DISCOVER  — run bash extract scripts to get authoritative model IDs
+ *   2. ENRICH    — ask each CLI's fast model to classify its own models into tiers
+ *   3. VALIDATE  — reject hallucinated IDs, check coverage & tier distribution
+ *   4. FALLBACK  — per-model: enrichment → previous catalog → name heuristic → balanced
+ *   5. WRITE     — serialize to src/modelCatalog.generated.json
  *
  * Usage:
  *   npx tsx scripts/refresh-catalog.ts
@@ -12,7 +16,7 @@
  *   ANTHROPIC_API_KEY, GEMINI_API_KEY / GOOGLE_API_KEY, OPENAI_API_KEY
  */
 
-import { execSync } from 'node:child_process';
+import { execSync, execFileSync } from 'node:child_process';
 import { readFileSync, writeFileSync, existsSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -22,15 +26,15 @@ const GENERATED_PATH = resolve(__dirname, '..', 'src', 'modelCatalog.generated.j
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
-interface ModelEntry {
+export interface EnrichmentEntry {
   id: string;
-  displayName: string;
   tier: 'fast' | 'balanced' | 'powerful';
+  displayName: string;
   description: string;
 }
 
-interface CLIResponse {
-  models: ModelEntry[];
+interface EnrichmentResponse {
+  models: EnrichmentEntry[];
 }
 
 interface GeneratedTier {
@@ -48,159 +52,327 @@ interface GeneratedFile {
   catalogs: Record<string, GeneratedCatalog>;
 }
 
-// ── Prompt ───────────────────────────────────────────────────────────────────
-
-function buildPrompt(provider: string): string {
-  return `You are reporting which models are available through the ${provider} CLI.
-Respond with ONLY valid JSON matching this exact schema — no markdown, no explanation, no code fences.
-
-{
-  "models": [
-    {
-      "id": "exact model ID string passed to --model or -m",
-      "displayName": "human-readable name",
-      "tier": "fast | balanced | powerful",
-      "description": "1 sentence on when to use this model"
-    }
-  ]
-}
-
-Rules:
-- ONLY include ${provider}'s own models — do NOT include models from other providers
-- Only include models currently available in this CLI
-- Classify: smallest/fastest models → "fast", mid-range → "balanced", largest/most capable → "powerful"
-- The "id" must be the exact string a user passes to the --model or -m flag
-- If unsure about a model, omit it`;
-}
-
-// ── CLI invocations ──────────────────────────────────────────────────────────
+// ── CLI configuration ────────────────────────────────────────────────────────
 
 interface CLIConfig {
   name: string;
   expectedPrefix: string;
-  buildCommand: (prompt: string) => string;
+  extractScript: string;
+  /** Pattern to find the cheapest/fastest model from discovered IDs for enrichment */
+  fastModelPattern: RegExp;
+  buildEnrichmentCommand: (model: string, prompt: string) => string;
 }
 
 const CLI_CONFIGS: CLIConfig[] = [
   {
     name: 'claude',
     expectedPrefix: 'claude-',
-    buildCommand: (prompt) =>
-      `claude --print --output-format text --model claude-haiku-4-5-20251001 ${shellQuote(prompt)}`,
+    extractScript: 'scripts/extract-claude.sh',
+    fastModelPattern: /haiku/i,
+    buildEnrichmentCommand: (model, prompt) =>
+      `claude --print --output-format text --model ${model} ${shellQuote(prompt)}`,
   },
   {
     name: 'gemini',
     expectedPrefix: 'gemini-',
-    buildCommand: (prompt) =>
-      `gemini -m gemini-2.5-flash -p ${shellQuote(prompt)}`,
+    extractScript: 'scripts/extract-gemini.sh',
+    fastModelPattern: /flash(?!.*preview)/i,
+    buildEnrichmentCommand: (model, prompt) =>
+      `gemini -m ${model} -p ${shellQuote(prompt)}`,
   },
   {
     name: 'codex',
     expectedPrefix: 'gpt-',
-    buildCommand: (prompt) =>
-      `codex exec --full-auto --skip-git-repo-check --color never -m gpt-5.1-codex-mini ${shellQuote(prompt)}`,
+    extractScript: 'scripts/extract-codex.sh',
+    fastModelPattern: /mini/i,
+    buildEnrichmentCommand: (model, prompt) =>
+      `codex exec --full-auto --skip-git-repo-check --color never -m ${model} ${shellQuote(prompt)}`,
   },
 ];
 
+/**
+ * Pick the cheapest model from discovered IDs to use for enrichment.
+ * Falls back to the first model in the list if no pattern match.
+ */
+export function pickEnrichmentModel(modelIds: string[], pattern: RegExp): string {
+  const match = modelIds.find((id) => pattern.test(id));
+  return match ?? modelIds[0];
+}
+
+// ── Utilities ────────────────────────────────────────────────────────────────
+
 function shellQuote(s: string): string {
-  // Single-quote the string, escaping any embedded single quotes
   return `'${s.replace(/'/g, "'\\''")}'`;
 }
 
-// ── Validation ───────────────────────────────────────────────────────────────
-
 const VALID_TIERS = new Set(['fast', 'balanced', 'powerful']);
 
-function validateResponse(raw: string, cliName: string): ModelEntry[] | null {
+// ── Phase 1: DISCOVER ────────────────────────────────────────────────────────
+
+function discoverModels(config: CLIConfig): string[] | null {
+  const scriptPath = resolve(__dirname, '..', config.extractScript);
+
+  console.log(`  [discover] Running ${config.extractScript}...`);
+
+  try {
+    const stdout = execFileSync('bash', [scriptPath], {
+      encoding: 'utf-8',
+      timeout: 120_000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    const parsed: unknown = JSON.parse(stdout.trim());
+
+    if (!Array.isArray(parsed) || parsed.length === 0) {
+      console.error(`  [discover] ${config.name}: script returned empty or non-array`);
+      return null;
+    }
+
+    const valid = parsed.filter(
+      (id: unknown): id is string =>
+        typeof id === 'string' && id.startsWith(config.expectedPrefix),
+    );
+
+    if (valid.length === 0) {
+      console.error(
+        `  [discover] ${config.name}: no IDs matching prefix "${config.expectedPrefix}"`,
+      );
+      return null;
+    }
+
+    console.log(`  [discover] ${config.name}: found ${valid.length} model IDs`);
+    return valid;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`  [discover] ${config.name}: extraction failed — ${message}`);
+    return null;
+  }
+}
+
+// ── Phase 2: ENRICH ──────────────────────────────────────────────────────────
+
+export function buildEnrichmentPrompt(cliName: string, modelIds: string[]): string {
+  return `You are classifying ${cliName} models into performance tiers.
+
+Here are the exact model IDs available in the ${cliName} CLI:
+${JSON.stringify(modelIds)}
+
+Classify EACH model into exactly one tier and respond with ONLY valid JSON (no markdown, no code fences, no explanation):
+
+{
+  "models": [
+    {
+      "id": "exact model ID from the list above",
+      "tier": "fast | balanced | powerful",
+      "displayName": "human-friendly name (e.g. 'Haiku', 'Sonnet 4', 'GPT-5.2 Codex')",
+      "description": "1 sentence on strengths/when to use"
+    }
+  ]
+}
+
+Rules:
+- You MUST classify EVERY model ID listed above. Do not skip any.
+- You MUST NOT invent model IDs. Only use IDs from the list.
+- Classify by relative capability: smallest/fastest -> "fast", mid-range -> "balanced", largest/most capable -> "powerful"
+- Each tier should have at least one model (if 3+ models are provided)
+- The "id" field must EXACTLY match one of the IDs provided above`;
+}
+
+function enrichModels(config: CLIConfig, modelIds: string[]): EnrichmentEntry[] | null {
+  const enrichmentModel = pickEnrichmentModel(modelIds, config.fastModelPattern);
+  const prompt = buildEnrichmentPrompt(config.name, modelIds);
+  const command = config.buildEnrichmentCommand(enrichmentModel, prompt);
+
+  console.log(`  [enrich] Querying ${config.name} CLI (model: ${enrichmentModel})...`);
+
+  try {
+    const stdout = execSync(command, {
+      encoding: 'utf-8',
+      timeout: 120_000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    return validateEnrichment(stdout, config.name, modelIds);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`  [enrich] ${config.name}: CLI invocation failed — ${message}`);
+    return null;
+  }
+}
+
+// ── Phase 3: VALIDATE ────────────────────────────────────────────────────────
+
+export function validateEnrichment(
+  raw: string,
+  cliName: string,
+  knownIds: string[],
+): EnrichmentEntry[] | null {
   // Strip markdown code fences if the LLM wrapped the response
   let cleaned = raw.trim();
   if (cleaned.startsWith('```')) {
     cleaned = cleaned.replace(/^```(?:json)?\s*\n?/, '').replace(/\n?```\s*$/, '');
   }
 
-  let parsed: CLIResponse;
+  let parsed: EnrichmentResponse;
   try {
     parsed = JSON.parse(cleaned);
   } catch {
-    console.error(`  ✗ ${cliName}: response is not valid JSON`);
+    console.error(`  [validate] ${cliName}: response is not valid JSON`);
     return null;
   }
 
   if (!Array.isArray(parsed.models) || parsed.models.length === 0) {
-    console.error(`  ✗ ${cliName}: response has no models array or it is empty`);
+    console.error(`  [validate] ${cliName}: no models array or it is empty`);
     return null;
   }
 
-  const valid: ModelEntry[] = [];
+  const knownSet = new Set(knownIds);
+  const valid: EnrichmentEntry[] = [];
+
   for (const m of parsed.models) {
     if (
       typeof m.id !== 'string' ||
-      !m.id.trim() ||
-      typeof m.displayName !== 'string' ||
       typeof m.tier !== 'string' ||
       !VALID_TIERS.has(m.tier) ||
+      typeof m.displayName !== 'string' ||
       typeof m.description !== 'string'
     ) {
-      console.warn(`  ⚠ ${cliName}: skipping invalid model entry: ${JSON.stringify(m)}`);
+      console.warn(`  [validate] ${cliName}: skipping malformed entry: ${JSON.stringify(m)}`);
       continue;
     }
+
+    // Reject invented model IDs
+    if (!knownSet.has(m.id)) {
+      console.warn(`  [validate] ${cliName}: rejecting invented model ID: "${m.id}"`);
+      continue;
+    }
+
     valid.push({
       id: m.id.trim(),
+      tier: m.tier as EnrichmentEntry['tier'],
       displayName: m.displayName.trim(),
-      tier: m.tier as ModelEntry['tier'],
       description: m.description.trim(),
     });
   }
 
   if (valid.length === 0) {
-    console.error(`  ✗ ${cliName}: no valid model entries after validation`);
+    console.error(`  [validate] ${cliName}: no valid entries after validation`);
     return null;
   }
 
+  // Coverage check — enrichment must cover at least 50% of known IDs
+  const coveredIds = new Set(valid.map((e) => e.id));
+  const coverageRatio = coveredIds.size / knownIds.length;
+  if (coverageRatio < 0.5) {
+    console.warn(
+      `  [validate] ${cliName}: low coverage (${coveredIds.size}/${knownIds.length}), rejecting enrichment`,
+    );
+    return null;
+  }
+
+  // Tier distribution — reject if all models land in the same tier (when 3+)
+  if (valid.length >= 3) {
+    const uniqueTiers = new Set(valid.map((e) => e.tier));
+    if (uniqueTiers.size === 1) {
+      console.warn(
+        `  [validate] ${cliName}: all ${valid.length} models in same tier "${[...uniqueTiers][0]}", rejecting`,
+      );
+      return null;
+    }
+  }
+
+  console.log(`  [validate] ${cliName}: ${valid.length}/${knownIds.length} models classified`);
   return valid;
 }
 
-// ── Query a single CLI ──────────────────────────────────────────────────────
+// ── Phase 4: FALLBACK ────────────────────────────────────────────────────────
 
-function queryCLI(config: CLIConfig): ModelEntry[] | null {
-  const prompt = buildPrompt(config.name);
-  const command = config.buildCommand(prompt);
+export function heuristicTier(
+  modelId: string,
+  cliName: string,
+): 'fast' | 'balanced' | 'powerful' {
+  // Use dash-delimited segments to avoid substring false positives
+  // (e.g. "gemini" contains "mini", "preview" does NOT contain "pro")
+  const lower = modelId.toLowerCase();
+  const segments = new Set(lower.split('-'));
 
-  console.log(`  ⟳ Querying ${config.name} CLI...`);
+  // Fast indicators
+  if (['mini', 'lite', 'haiku', 'small', 'nano'].some((p) => segments.has(p))) return 'fast';
 
-  try {
-    const stdout = execSync(command, {
-      encoding: 'utf-8',
-      timeout: 120_000, // 2 minute timeout
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
-    const models = validateResponse(stdout, config.name);
-    if (!models) return null;
+  // Powerful indicators
+  if (['opus', 'pro', 'max', 'ultra'].some((p) => segments.has(p))) return 'powerful';
 
-    // Filter out models that don't match the expected provider prefix
-    const filtered = models.filter((m) => m.id.startsWith(config.expectedPrefix));
-    const dropped = models.length - filtered.length;
-    if (dropped > 0) {
-      console.warn(`  ⚠ ${config.name}: dropped ${dropped} model(s) not matching prefix "${config.expectedPrefix}"`);
-    }
-    return filtered.length > 0 ? filtered : null;
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    console.error(`  ✗ ${config.name}: CLI invocation failed — ${message}`);
-    return null;
+  // CLI-specific patterns
+  if (cliName === 'gemini') {
+    if (segments.has('flash') && !segments.has('preview')) return 'fast';
+    if (segments.has('flash') && segments.has('preview')) return 'balanced';
   }
+
+  if (cliName === 'claude') {
+    if (segments.has('sonnet')) return 'balanced';
+  }
+
+  if (cliName === 'codex') {
+    if (segments.has('codex') && !segments.has('mini') && !segments.has('max'))
+      return 'balanced';
+    if (lower.startsWith('gpt-') && !segments.has('codex')) return 'powerful';
+  }
+
+  // Default
+  return 'balanced';
 }
 
-// ── Build catalog from model entries ────────────────────────────────────────
+export function assignTiers(
+  modelIds: string[],
+  enrichment: EnrichmentEntry[] | null,
+  previousCatalog: GeneratedCatalog | null,
+  cliName: string,
+): GeneratedCatalog {
+  // Build lookup maps
+  const enrichmentMap = new Map<string, EnrichmentEntry>();
+  if (enrichment) {
+    for (const e of enrichment) enrichmentMap.set(e.id, e);
+  }
 
-function buildCatalog(cliName: string, models: ModelEntry[]): GeneratedCatalog {
+  const previousTierMap = new Map<string, 'fast' | 'balanced' | 'powerful'>();
+  if (previousCatalog) {
+    for (const t of previousCatalog.tiers) {
+      for (const id of t.models) {
+        previousTierMap.set(id, t.tier);
+      }
+    }
+  }
+
+  // Assign each model to a tier via the fallback chain
+  const tierBuckets: Record<string, string[]> = { fast: [], balanced: [], powerful: [] };
+
+  for (const id of modelIds) {
+    let tier: 'fast' | 'balanced' | 'powerful';
+    let source: string;
+
+    const enriched = enrichmentMap.get(id);
+    if (enriched) {
+      tier = enriched.tier;
+      source = 'enrichment';
+    } else if (previousTierMap.has(id)) {
+      tier = previousTierMap.get(id)!;
+      source = 'previous-catalog';
+    } else {
+      tier = heuristicTier(id, cliName);
+      source = 'heuristic';
+    }
+
+    tierBuckets[tier].push(id);
+    console.log(`    ${id} -> ${tier} (${source})`);
+  }
+
+  // Build GeneratedCatalog preserving tier order and omitting empty tiers
   const tierOrder: Array<'fast' | 'balanced' | 'powerful'> = ['fast', 'balanced', 'powerful'];
   const tiers: GeneratedTier[] = [];
 
   for (const tier of tierOrder) {
-    const tierModels = models.filter((m) => m.tier === tier).map((m) => m.id);
-    if (tierModels.length > 0) {
-      tiers.push({ tier, models: tierModels });
+    if (tierBuckets[tier].length > 0) {
+      tiers.push({ tier, models: tierBuckets[tier] });
     }
   }
 
@@ -218,31 +390,51 @@ function loadExisting(): GeneratedFile | null {
   }
 }
 
-// ── Main ─────────────────────────────────────────────────────────────────────
+// ── Phase 5: WRITE (main orchestrator) ───────────────────────────────────────
 
 function main(): void {
   console.log('Refreshing model catalog...\n');
 
   const existing = loadExisting();
   const catalogs: Record<string, GeneratedCatalog> = {};
-  let successCount = 0;
+  let anyDiscoverySuccess = false;
 
   for (const config of CLI_CONFIGS) {
-    const models = queryCLI(config);
-    if (models) {
-      catalogs[config.name] = buildCatalog(config.name, models);
-      console.log(`  ✓ ${config.name}: ${models.length} models found\n`);
-      successCount++;
-    } else if (existing?.catalogs[config.name]) {
-      console.log(`  ↩ ${config.name}: keeping existing catalog (fallback)\n`);
-      catalogs[config.name] = existing.catalogs[config.name];
-    } else {
-      console.warn(`  ⚠ ${config.name}: no data available (no fallback)\n`);
+    console.log(`\n--- ${config.name.toUpperCase()} ---`);
+
+    // Phase 1: DISCOVER
+    const modelIds = discoverModels(config);
+
+    if (!modelIds) {
+      // Discovery failed — fall back to entire previous catalog for this CLI
+      if (existing?.catalogs[config.name]) {
+        console.log(`  [fallback] keeping entire previous catalog for ${config.name}`);
+        catalogs[config.name] = existing.catalogs[config.name];
+      } else {
+        console.warn(`  [fallback] no previous catalog for ${config.name}, skipping`);
+      }
+      continue;
     }
+
+    anyDiscoverySuccess = true;
+
+    // Phase 2: ENRICH
+    const enrichment = enrichModels(config, modelIds);
+
+    // Phase 3: VALIDATE (inside enrichModels → validateEnrichment)
+
+    // Phase 4: FALLBACK + ASSIGN
+    const previousCatalog = existing?.catalogs[config.name] ?? null;
+    catalogs[config.name] = assignTiers(modelIds, enrichment, previousCatalog, config.name);
+
+    const totalModels = catalogs[config.name].tiers.reduce((sum, t) => sum + t.models.length, 0);
+    console.log(
+      `  [result] ${config.name}: ${totalModels} models across ${catalogs[config.name].tiers.length} tiers`,
+    );
   }
 
-  if (successCount === 0 && !existing) {
-    console.error('\n✗ All CLIs failed and no existing catalog to fall back to.');
+  if (!anyDiscoverySuccess && !existing) {
+    console.error('\nAll CLIs failed discovery and no existing catalog. Aborting.');
     process.exit(1);
   }
 
@@ -252,8 +444,17 @@ function main(): void {
   };
 
   writeFileSync(GENERATED_PATH, JSON.stringify(output, null, 2) + '\n', 'utf-8');
-  console.log(`✓ Wrote ${GENERATED_PATH}`);
-  console.log(`  ${successCount}/${CLI_CONFIGS.length} CLIs refreshed successfully.`);
+  console.log(`\n✓ Wrote ${GENERATED_PATH}`);
+
+  const cliCount = Object.keys(catalogs).length;
+  console.log(`  ${cliCount}/${CLI_CONFIGS.length} CLIs in catalog.`);
 }
 
-main();
+// Only run main() when executed directly (not when imported by tests)
+const isDirectExecution =
+  process.argv[1]?.endsWith('refresh-catalog.ts') ||
+  process.argv[1]?.endsWith('refresh-catalog.js');
+
+if (isDirectExecution) {
+  main();
+}

--- a/src/modelCatalog.generated.json
+++ b/src/modelCatalog.generated.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-03-05T21:53:48.446Z",
+  "generatedAt": "2026-03-06T04:31:11.325Z",
   "catalogs": {
     "claude": {
       "cli": "claude",
@@ -7,12 +7,13 @@
         {
           "tier": "fast",
           "models": [
-            "claude-haiku-4-5-20251001"
+            "claude-haiku-4-5"
           ]
         },
         {
           "tier": "balanced",
           "models": [
+            "claude-sonnet-4-5",
             "claude-sonnet-4-6"
           ]
         },
@@ -37,14 +38,15 @@
         {
           "tier": "balanced",
           "models": [
+            "gemini-2.5-pro",
             "gemini-3-flash-preview"
           ]
         },
         {
           "tier": "powerful",
           "models": [
-            "gemini-3.1-pro-preview",
-            "gemini-2.5-pro"
+            "gemini-3-pro-preview",
+            "gemini-3.1-pro-preview"
           ]
         }
       ]
@@ -55,21 +57,27 @@
         {
           "tier": "fast",
           "models": [
+            "gpt-5-codex-mini",
             "gpt-5.1-codex-mini"
           ]
         },
         {
           "tier": "balanced",
           "models": [
-            "gpt-5.2-codex"
+            "gpt-5",
+            "gpt-5-codex",
+            "gpt-5.1",
+            "gpt-5.1-codex",
+            "gpt-5.2",
+            "gpt-5.2-codex",
+            "gpt-5.3-codex"
           ]
         },
         {
           "tier": "powerful",
           "models": [
-            "gpt-5.3-codex",
             "gpt-5.1-codex-max",
-            "gpt-5.2"
+            "gpt-5.4"
           ]
         }
       ]

--- a/tests/refreshCatalog.test.ts
+++ b/tests/refreshCatalog.test.ts
@@ -1,0 +1,298 @@
+import { describe, it, expect } from 'vitest';
+import {
+  heuristicTier,
+  validateEnrichment,
+  assignTiers,
+  buildEnrichmentPrompt,
+  pickEnrichmentModel,
+} from '../scripts/refresh-catalog.js';
+import type { EnrichmentEntry } from '../scripts/refresh-catalog.js';
+
+// ===========================================================================
+// heuristicTier
+// ===========================================================================
+
+describe('heuristicTier', () => {
+  describe('fast tier', () => {
+    it('classifies haiku as fast', () => {
+      expect(heuristicTier('claude-haiku-4-5-20251001', 'claude')).toBe('fast');
+    });
+
+    it('classifies mini as fast', () => {
+      expect(heuristicTier('gpt-5.1-codex-mini', 'codex')).toBe('fast');
+    });
+
+    it('classifies lite as fast', () => {
+      expect(heuristicTier('gemini-2.5-flash-lite', 'gemini')).toBe('fast');
+    });
+
+    it('classifies flash (without preview) as fast for gemini', () => {
+      expect(heuristicTier('gemini-2.5-flash', 'gemini')).toBe('fast');
+    });
+  });
+
+  describe('balanced tier', () => {
+    it('classifies sonnet as balanced for claude', () => {
+      expect(heuristicTier('claude-sonnet-4-6', 'claude')).toBe('balanced');
+    });
+
+    it('classifies flash-preview as balanced for gemini', () => {
+      expect(heuristicTier('gemini-3-flash-preview', 'gemini')).toBe('balanced');
+    });
+
+    it('classifies codex (no mini/max suffix) as balanced', () => {
+      expect(heuristicTier('gpt-5.2-codex', 'codex')).toBe('balanced');
+    });
+
+    it('defaults unknown models to balanced', () => {
+      expect(heuristicTier('claude-mystery-9000', 'claude')).toBe('balanced');
+    });
+  });
+
+  describe('powerful tier', () => {
+    it('classifies opus as powerful', () => {
+      expect(heuristicTier('claude-opus-4-6', 'claude')).toBe('powerful');
+    });
+
+    it('classifies pro as powerful', () => {
+      expect(heuristicTier('gemini-2.5-pro', 'gemini')).toBe('powerful');
+      expect(heuristicTier('gemini-3.1-pro-preview', 'gemini')).toBe('powerful');
+    });
+
+    it('classifies max as powerful', () => {
+      expect(heuristicTier('gpt-5.1-codex-max', 'codex')).toBe('powerful');
+    });
+
+    it('classifies plain gpt (without codex suffix) as powerful', () => {
+      expect(heuristicTier('gpt-5.2', 'codex')).toBe('powerful');
+    });
+  });
+});
+
+// ===========================================================================
+// validateEnrichment
+// ===========================================================================
+
+describe('validateEnrichment', () => {
+  const knownIds = ['model-a', 'model-b', 'model-c'];
+
+  function makeResponse(models: object[]): string {
+    return JSON.stringify({ models });
+  }
+
+  it('accepts valid enrichment with all known IDs', () => {
+    const raw = makeResponse([
+      { id: 'model-a', tier: 'fast', displayName: 'A', description: 'fast one' },
+      { id: 'model-b', tier: 'balanced', displayName: 'B', description: 'mid one' },
+      { id: 'model-c', tier: 'powerful', displayName: 'C', description: 'big one' },
+    ]);
+    const result = validateEnrichment(raw, 'test', knownIds);
+    expect(result).toHaveLength(3);
+    expect(result!.map((e) => e.id)).toEqual(['model-a', 'model-b', 'model-c']);
+  });
+
+  it('rejects invented model IDs while keeping valid ones', () => {
+    const raw = makeResponse([
+      { id: 'model-a', tier: 'fast', displayName: 'A', description: 'fast' },
+      { id: 'model-FAKE', tier: 'balanced', displayName: 'Fake', description: 'made up' },
+      { id: 'model-c', tier: 'powerful', displayName: 'C', description: 'big' },
+    ]);
+    const result = validateEnrichment(raw, 'test', knownIds);
+    expect(result).toHaveLength(2);
+    expect(result!.map((e) => e.id)).toEqual(['model-a', 'model-c']);
+  });
+
+  it('rejects when all models in same tier (3+ models)', () => {
+    const raw = makeResponse([
+      { id: 'model-a', tier: 'balanced', displayName: 'A', description: 'd' },
+      { id: 'model-b', tier: 'balanced', displayName: 'B', description: 'd' },
+      { id: 'model-c', tier: 'balanced', displayName: 'C', description: 'd' },
+    ]);
+    expect(validateEnrichment(raw, 'test', knownIds)).toBeNull();
+  });
+
+  it('allows same tier when fewer than 3 models', () => {
+    const twoIds = ['model-a', 'model-b'];
+    const raw = makeResponse([
+      { id: 'model-a', tier: 'fast', displayName: 'A', description: 'd' },
+      { id: 'model-b', tier: 'fast', displayName: 'B', description: 'd' },
+    ]);
+    const result = validateEnrichment(raw, 'test', twoIds);
+    expect(result).toHaveLength(2);
+  });
+
+  it('rejects when coverage below 50%', () => {
+    const fiveIds = ['m1', 'm2', 'm3', 'm4', 'm5'];
+    const raw = makeResponse([
+      { id: 'm1', tier: 'fast', displayName: 'M1', description: 'd' },
+      { id: 'm2', tier: 'balanced', displayName: 'M2', description: 'd' },
+    ]);
+    expect(validateEnrichment(raw, 'test', fiveIds)).toBeNull();
+  });
+
+  it('strips markdown code fences', () => {
+    const inner = makeResponse([
+      { id: 'model-a', tier: 'fast', displayName: 'A', description: 'f' },
+      { id: 'model-b', tier: 'powerful', displayName: 'B', description: 'p' },
+    ]);
+    const raw = '```json\n' + inner + '\n```';
+    expect(validateEnrichment(raw, 'test', ['model-a', 'model-b'])).toHaveLength(2);
+  });
+
+  it('returns null for non-JSON', () => {
+    expect(validateEnrichment('not json at all', 'test', knownIds)).toBeNull();
+  });
+
+  it('returns null for empty models array', () => {
+    expect(validateEnrichment('{"models":[]}', 'test', knownIds)).toBeNull();
+  });
+
+  it('skips entries with invalid tier values', () => {
+    const raw = makeResponse([
+      { id: 'model-a', tier: 'fast', displayName: 'A', description: 'd' },
+      { id: 'model-b', tier: 'INVALID', displayName: 'B', description: 'd' },
+      { id: 'model-c', tier: 'powerful', displayName: 'C', description: 'd' },
+    ]);
+    const result = validateEnrichment(raw, 'test', knownIds);
+    expect(result).toHaveLength(2);
+  });
+
+  it('skips entries with missing fields', () => {
+    const raw = makeResponse([
+      { id: 'model-a', tier: 'fast', displayName: 'A', description: 'd' },
+      { id: 'model-b', tier: 'balanced' }, // missing displayName, description
+      { id: 'model-c', tier: 'powerful', displayName: 'C', description: 'd' },
+    ]);
+    const result = validateEnrichment(raw, 'test', knownIds);
+    expect(result).toHaveLength(2);
+  });
+});
+
+// ===========================================================================
+// assignTiers
+// ===========================================================================
+
+describe('assignTiers', () => {
+  it('uses enrichment when available', () => {
+    const ids = ['model-a', 'model-b'];
+    const enrichment: EnrichmentEntry[] = [
+      { id: 'model-a', tier: 'fast', displayName: 'A', description: 'f' },
+      { id: 'model-b', tier: 'powerful', displayName: 'B', description: 'p' },
+    ];
+    const result = assignTiers(ids, enrichment, null, 'test');
+    expect(result.cli).toBe('test');
+    expect(result.tiers).toHaveLength(2);
+    expect(result.tiers[0]).toEqual({ tier: 'fast', models: ['model-a'] });
+    expect(result.tiers[1]).toEqual({ tier: 'powerful', models: ['model-b'] });
+  });
+
+  it('falls back to previous catalog for unenriched models', () => {
+    const ids = ['model-a', 'model-b'];
+    const enrichment: EnrichmentEntry[] = [
+      { id: 'model-a', tier: 'fast', displayName: 'A', description: 'f' },
+    ];
+    const previous = {
+      cli: 'test',
+      tiers: [{ tier: 'powerful' as const, models: ['model-b'] }],
+    };
+    const result = assignTiers(ids, enrichment, previous, 'test');
+    expect(result.tiers.find((t) => t.tier === 'fast')?.models).toContain('model-a');
+    expect(result.tiers.find((t) => t.tier === 'powerful')?.models).toContain('model-b');
+  });
+
+  it('falls back to heuristic for completely new models', () => {
+    const ids = ['claude-haiku-99'];
+    const result = assignTiers(ids, null, null, 'claude');
+    expect(result.tiers).toHaveLength(1);
+    expect(result.tiers[0]).toEqual({ tier: 'fast', models: ['claude-haiku-99'] });
+  });
+
+  it('returns empty tiers for empty model list', () => {
+    const result = assignTiers([], null, null, 'test');
+    expect(result.tiers).toHaveLength(0);
+  });
+
+  it('preserves tier order (fast, balanced, powerful)', () => {
+    const ids = ['claude-opus-1', 'claude-haiku-1', 'claude-sonnet-1'];
+    const result = assignTiers(ids, null, null, 'claude');
+    const tierNames = result.tiers.map((t) => t.tier);
+    expect(tierNames).toEqual(['fast', 'balanced', 'powerful']);
+  });
+
+  it('omits empty tiers', () => {
+    const ids = ['claude-haiku-1', 'claude-opus-1'];
+    const result = assignTiers(ids, null, null, 'claude');
+    expect(result.tiers).toHaveLength(2);
+    expect(result.tiers.map((t) => t.tier)).toEqual(['fast', 'powerful']);
+  });
+
+  it('enrichment takes priority over previous catalog', () => {
+    const ids = ['model-a'];
+    const enrichment: EnrichmentEntry[] = [
+      { id: 'model-a', tier: 'powerful', displayName: 'A', description: 'p' },
+    ];
+    const previous = {
+      cli: 'test',
+      tiers: [{ tier: 'fast' as const, models: ['model-a'] }],
+    };
+    const result = assignTiers(ids, enrichment, previous, 'test');
+    expect(result.tiers[0]).toEqual({ tier: 'powerful', models: ['model-a'] });
+  });
+});
+
+// ===========================================================================
+// buildEnrichmentPrompt
+// ===========================================================================
+
+describe('buildEnrichmentPrompt', () => {
+  it('includes the CLI name', () => {
+    const prompt = buildEnrichmentPrompt('claude', ['claude-opus-4-6']);
+    expect(prompt).toContain('claude');
+  });
+
+  it('includes all model IDs', () => {
+    const ids = ['model-a', 'model-b', 'model-c'];
+    const prompt = buildEnrichmentPrompt('test', ids);
+    for (const id of ids) {
+      expect(prompt).toContain(id);
+    }
+  });
+
+  it('includes tier classification instructions', () => {
+    const prompt = buildEnrichmentPrompt('test', ['m1']);
+    expect(prompt).toContain('fast');
+    expect(prompt).toContain('balanced');
+    expect(prompt).toContain('powerful');
+  });
+});
+
+// ===========================================================================
+// pickEnrichmentModel
+// ===========================================================================
+
+describe('pickEnrichmentModel', () => {
+  it('picks haiku for claude', () => {
+    const ids = ['claude-opus-4-6', 'claude-sonnet-4-6', 'claude-haiku-4-5-20251001'];
+    expect(pickEnrichmentModel(ids, /haiku/i)).toBe('claude-haiku-4-5-20251001');
+  });
+
+  it('picks flash (non-preview) for gemini', () => {
+    const ids = ['gemini-2.5-pro', 'gemini-3-flash-preview', 'gemini-2.5-flash', 'gemini-2.5-flash-lite'];
+    expect(pickEnrichmentModel(ids, /flash(?!.*preview)/i)).toBe('gemini-2.5-flash');
+  });
+
+  it('picks mini for codex', () => {
+    const ids = ['gpt-5.2-codex', 'gpt-5.1-codex-mini', 'gpt-5.3-codex'];
+    expect(pickEnrichmentModel(ids, /mini/i)).toBe('gpt-5.1-codex-mini');
+  });
+
+  it('falls back to first model if no pattern match', () => {
+    const ids = ['unknown-model-a', 'unknown-model-b'];
+    expect(pickEnrichmentModel(ids, /haiku/i)).toBe('unknown-model-a');
+  });
+
+  it('handles future model names gracefully', () => {
+    const ids = ['claude-haiku-99-turbo', 'claude-opus-99'];
+    expect(pickEnrichmentModel(ids, /haiku/i)).toBe('claude-haiku-99-turbo');
+  });
+});


### PR DESCRIPTION
## Summary
- Refactors the nightly model catalog refresh to use bash extract scripts as the **source of truth** for model ID discovery, replacing unreliable LLM self-reporting
- CLIs are still used, but only for **enrichment** — each CLI's fast model classifies its own models into tiers (fast/balanced/powerful)
- Multi-layered per-model fallback: enrichment → previous catalog → name-pattern heuristic → default "balanced"

## Changes
- **`scripts/refresh-catalog.ts`** — Rewritten with 5-phase flow: discover → enrich → validate → fallback → write
- **`scripts/extract-gemini.sh`** — Filter out "custom" models
- **`scripts/extract-codex.sh`** — Filter out "oss" models
- **`tests/refreshCatalog.test.ts`** — 37 new unit tests for heuristicTier, validateEnrichment, assignTiers, pickEnrichmentModel, buildEnrichmentPrompt
- **`src/modelCatalog.generated.json`** — Updated with fresh catalog from new pipeline
- No changes to modelCatalog.ts, tierConfig.ts, workflow YAML, or existing tests

## Key design decisions
- `execFileSync('bash', [script])` for extract scripts (avoids shell injection)
- Dynamic enrichment model selection via regex patterns (no hardcoded model names — self-updating)
- Invented ID rejection: any model ID not from the bash scripts is dropped
- Mono-tier and coverage validation prevents garbage enrichment data
- Segment-based heuristic matching (split on `-`) avoids false positives like "gemini" matching "mini"

## Test plan
- [x] 191/191 tests pass (138 existing + 37 new + 16 parameterized)
- [x] `npm run lint` passes
- [x] `npm run build` succeeds
- [x] Local end-to-end run produces valid catalog with correct tier assignments
- [ ] CI tests pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude, Codex, and Gemini <noreply@anthropic.com>