### PR TITLE
fix(ci): persist-credentials: false for app token push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: main
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6


### PR DESCRIPTION
## Summary
One-line fix: `actions/checkout` configures a credential helper with `GITHUB_TOKEN` that overrides `git remote set-url`. The push was authenticating as `github-actions[bot]` (GITHUB_TOKEN) instead of the GitHub App.

Adding `persist-credentials: false` to the bump job's checkout prevents this, so the app token set via `git remote set-url` is actually used.

## Root cause
```
remote: Permission to osanoai/multicli.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/osanoai/multicli.git/': The requested URL returned error: 403
```

The credential helper from `actions/checkout` was intercepting the push and using `GITHUB_TOKEN` instead of the app token we configured via `git remote set-url`.

## Test plan
- [ ] Merge and verify the bump job successfully pushes the branch and creates the PR

Co-Authored-By: Claude, Codex, and Gemini