### PR TITLE
fix: skip catalog write when only timestamp changed

### DIFF
--- a/scripts/refresh-catalog.ts
+++ b/scripts/refresh-catalog.ts
@@ -457,6 +457,17 @@ function main(): void {
     process.exit(1);
   }
 
+  // Compare catalog data — skip write if nothing meaningful changed.
+  // This avoids opening PRs that only update the generatedAt timestamp.
+  if (existing) {
+    const oldCatalogs = JSON.stringify(existing.catalogs);
+    const newCatalogs = JSON.stringify(catalogs);
+    if (oldCatalogs === newCatalogs) {
+      console.log('\n⊘ No catalog changes detected — skipping write.');
+      return;
+    }
+  }
+
   const output: GeneratedFile = {
     generatedAt: new Date().toISOString(),
     catalogs,


### PR DESCRIPTION
## Summary
- The nightly `refresh-catalog.yml` workflow always wrote `modelCatalog.generated.json` with a fresh `generatedAt` timestamp, even when model data was identical
- This caused `git diff --quiet` to detect a change every run, opening a no-op PR daily (e.g. commit `ea2a887`)
- Now compares the `catalogs` content before writing — only updates the file (and timestamp) when actual model data has changed
- When nothing changed, logs `⊘ No catalog changes detected — skipping write.` and exits cleanly

## Test plan
- [x] `npm run lint` — type check passes
- [x] `npm test` — 194 tests pass (13 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)