### PR TITLE
ci: skip release workflow for admin-only pushes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,12 @@ name: Release & Publish
 on:
   push:
     branches: [main]
+    paths:
+      - 'src/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'tsconfig.json'
+      - 'README.md'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary
- Adds GitHub's native `on.push.paths` filter to the release workflow
- The workflow now only runs when release-relevant files change: `src/**`, `package.json`, `package-lock.json`, `tsconfig.json`, `README.md`
- Admin-only pushes (AGENTS.md, CI tweaks, test updates, scripts) are silently skipped — no bump PR, no wasted CI minutes

## Bump→publish cycle preserved
1. Admin push (e.g. AGENTS.md only) → paths filter doesn't match → workflow doesn't run ✓
2. Code push (e.g. src/index.ts) → paths matches → bump PR opened ✓
3. Bump PR merges (package.json + package-lock.json) → paths matches → publish to npm ✓
4. Manual major/minor bump in package.json → paths matches → publishes directly ✓
5. `workflow_dispatch` → always runs (paths filters don't apply) ✓

## Why these files
| Path | Reason |
|------|--------|
| `src/**` | Compiles to `dist/` — core package content |
| `package.json` | Version, deps, entry points. Must be included or bump→publish cycle breaks |
| `package-lock.json` | Modified alongside package.json by bump PR |
| `tsconfig.json` | Affects compiled output |
| `README.md` | Shipped in npm package per `package.json#files` |

## Test plan
- [x] Verify paths filter syntax is valid YAML
- [ ] After merge, push an admin-only change and confirm release workflow does NOT trigger
- [ ] Confirm `workflow_dispatch` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)