### PR TITLE
fix: add explicit Codex CLI login step for CI catalog refresh

### DIFF
--- a/.github/workflows/refresh-catalog.yml
+++ b/.github/workflows/refresh-catalog.yml
@@ -32,6 +32,11 @@ jobs:
           npm install -g --ignore-scripts @anthropic-ai/claude-code @google/gemini-cli @openai/codex
         continue-on-error: true
 
+      - name: Login Codex CLI
+        run: echo "$OPENAI_API_KEY" | codex login --with-api-key
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+
       - name: Refresh catalog
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary
- The Codex CLI does not use `OPENAI_API_KEY` from the environment for authentication — it requires an explicit `codex login --with-api-key` step
- Without this, the nightly catalog refresh gets `401 Unauthorized` from the OpenAI API and falls back to stale previous-catalog data
- Adds a login step between CLI install and catalog refresh in the workflow

## Test plan
- [ ] Trigger `refresh-catalog.yml` via `workflow_dispatch` and verify the Codex enrichment step no longer returns 401 errors

🤖 Generated with Claude, Codex, and Gemini