### PR TITLE
feat: add model probe phase to catalog refresh

### DIFF
--- a/scripts/refresh-catalog.ts
+++ b/scripts/refresh-catalog.ts
@@ -149,6 +149,37 @@ function discoverModels(config: CLIConfig): string[] | null {
   }
 }
 
+// ── Phase 1.5: PROBE ────────────────────────────────────────────────────
+
+/**
+ * Probe each discovered model by running a trivial CLI prompt.
+ * Returns only the model IDs that respond successfully.
+ */
+export function probeModels(config: CLIConfig, modelIds: string[]): string[] {
+  console.log(`  [probe] Testing ${modelIds.length} models for availability...`);
+
+  const valid: string[] = [];
+
+  for (const id of modelIds) {
+    const command = config.buildEnrichmentCommand(id, 'respond with OK');
+    try {
+      execSync(command, {
+        encoding: 'utf-8',
+        timeout: 30_000,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+      valid.push(id);
+      console.log(`    ${id}: available`);
+    } catch (err) {
+      const reason = err instanceof Error ? err.message.split('\n')[0] : String(err);
+      console.warn(`    ${id}: unavailable — ${reason}`);
+    }
+  }
+
+  console.log(`  [probe] ${valid.length}/${modelIds.length} models available`);
+  return valid;
+}
+
 // ── Phase 2: ENRICH ──────────────────────────────────────────────────────────
 
 export function buildEnrichmentPrompt(cliName: string, modelIds: string[]): string {
@@ -416,16 +447,30 @@ function main(): void {
       continue;
     }
 
+    // Phase 1.5: PROBE — test each model for availability
+    const validIds = probeModels(config, modelIds);
+
+    if (validIds.length === 0) {
+      console.warn(`  [probe] all models failed probing for ${config.name}`);
+      if (existing?.catalogs[config.name]) {
+        console.log(`  [fallback] keeping entire previous catalog for ${config.name}`);
+        catalogs[config.name] = existing.catalogs[config.name];
+      } else {
+        console.warn(`  [fallback] no previous catalog for ${config.name}, skipping`);
+      }
+      continue;
+    }
+
     anyDiscoverySuccess = true;
 
     // Phase 2: ENRICH
-    const enrichment = enrichModels(config, modelIds);
+    const enrichment = enrichModels(config, validIds);
 
     // Phase 3: VALIDATE (inside enrichModels → validateEnrichment)
 
     // Phase 4: FALLBACK + ASSIGN
     const previousCatalog = existing?.catalogs[config.name] ?? null;
-    catalogs[config.name] = assignTiers(modelIds, enrichment, previousCatalog, config.name);
+    catalogs[config.name] = assignTiers(validIds, enrichment, previousCatalog, config.name);
 
     const totalModels = catalogs[config.name].tiers.reduce((sum, t) => sum + t.models.length, 0);
     console.log(

--- a/tests/refreshCatalog.test.ts
+++ b/tests/refreshCatalog.test.ts
@@ -1,10 +1,11 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
   heuristicTier,
   validateEnrichment,
   assignTiers,
   buildEnrichmentPrompt,
   pickEnrichmentModel,
+  probeModels,
 } from '../scripts/refresh-catalog.js';
 import type { EnrichmentEntry } from '../scripts/refresh-catalog.js';
 
@@ -294,5 +295,73 @@ describe('pickEnrichmentModel', () => {
   it('handles future model names gracefully', () => {
     const ids = ['claude-haiku-99-turbo', 'claude-opus-99'];
     expect(pickEnrichmentModel(ids, /haiku/i)).toBe('claude-haiku-99-turbo');
+  });
+});
+
+// ===========================================================================
+// probeModels
+// ===========================================================================
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...actual,
+    execSync: vi.fn(actual.execSync),
+    execFileSync: actual.execFileSync,
+  };
+});
+
+import { execSync } from 'node:child_process';
+const mockExecSync = vi.mocked(execSync);
+
+describe('probeModels', () => {
+  const fakeConfig = {
+    name: 'test',
+    expectedPrefix: 'model-',
+    extractScript: 'scripts/extract-test.sh',
+    fastModelPattern: /mini/i,
+    buildEnrichmentCommand: (model: string, prompt: string) =>
+      `test-cli -m ${model} '${prompt}'`,
+  };
+
+  beforeEach(() => {
+    mockExecSync.mockReset();
+  });
+
+  it('returns all models when all probes succeed', () => {
+    mockExecSync.mockReturnValue('OK');
+    const result = probeModels(fakeConfig, ['model-a', 'model-b', 'model-c']);
+    expect(result).toEqual(['model-a', 'model-b', 'model-c']);
+    expect(mockExecSync).toHaveBeenCalledTimes(3);
+  });
+
+  it('filters out models that fail probing', () => {
+    mockExecSync
+      .mockReturnValueOnce('OK')           // model-a: success
+      .mockImplementationOnce(() => { throw new Error('model not found'); }) // model-b: fail
+      .mockReturnValueOnce('OK');           // model-c: success
+    const result = probeModels(fakeConfig, ['model-a', 'model-b', 'model-c']);
+    expect(result).toEqual(['model-a', 'model-c']);
+  });
+
+  it('returns empty array when all probes fail', () => {
+    mockExecSync.mockImplementation(() => { throw new Error('fail'); });
+    const result = probeModels(fakeConfig, ['model-a', 'model-b']);
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty array for empty input', () => {
+    const result = probeModels(fakeConfig, []);
+    expect(result).toEqual([]);
+    expect(mockExecSync).not.toHaveBeenCalled();
+  });
+
+  it('calls buildEnrichmentCommand with trivial probe prompt', () => {
+    mockExecSync.mockReturnValue('OK');
+    probeModels(fakeConfig, ['model-a']);
+    expect(mockExecSync).toHaveBeenCalledWith(
+      expect.stringContaining('respond with OK'),
+      expect.objectContaining({ timeout: 30_000 }),
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Adds a new **probe phase** (Phase 1.5) between DISCOVER and ENRICH in the catalog refresh script
- Tests each discovered model by running a trivial CLI prompt (`respond with OK`) before including it
- Models that fail (e.g., `gpt-5-codex-mini` returns "model does not exist") are excluded from the catalog
- If all models fail probing for a CLI, falls back to the previous catalog (same as discovery failure)
- Logs the failure reason for each unavailable model to aid CI debugging

## Why
The Codex repo's `models.json` lists model slugs that don't all work via the API. Without probing, the enrichment step picks one of these bad models, fails, and falls back to stale previous-catalog data — meaning the catalog never actually refreshes for Codex.

## Test plan
- [x] 5 new unit tests for `probeModels()` (all pass)
- [x] All 199 tests pass, build clean
- [x] Reviewed by Codex and Gemini — both confirmed correctness
- [ ] Trigger `refresh-catalog.yml` via `workflow_dispatch` after merge to verify end-to-end

🤖 Generated with Claude, Codex, and Gemini