### PR TITLE
fix: add retry logic for transient probe failures

### DIFF
--- a/scripts/refresh-catalog.ts
+++ b/scripts/refresh-catalog.ts
@@ -151,8 +151,12 @@ function discoverModels(config: CLIConfig): string[] | null {
 
 // ── Phase 1.5: PROBE ────────────────────────────────────────────────────
 
+const TRANSIENT_PATTERNS = /ETIMEDOUT|ECONNRESET|ECONNREFUSED|EPIPE|socket hang up|timeout|rate.?limit|429|503|502/i;
+const PROBE_MAX_RETRIES = 3;
+
 /**
  * Probe each discovered model by running a trivial CLI prompt.
+ * Retries up to PROBE_MAX_RETRIES times on transient errors (timeouts, network).
  * Returns only the model IDs that respond successfully.
  */
 export function probeModels(config: CLIConfig, modelIds: string[]): string[] {
@@ -162,17 +166,31 @@ export function probeModels(config: CLIConfig, modelIds: string[]): string[] {
 
   for (const id of modelIds) {
     const command = config.buildEnrichmentCommand(id, 'respond with OK');
-    try {
-      execSync(command, {
-        encoding: 'utf-8',
-        timeout: 30_000,
-        stdio: ['pipe', 'pipe', 'pipe'],
-      });
+    let succeeded = false;
+
+    for (let attempt = 1; attempt <= PROBE_MAX_RETRIES; attempt++) {
+      try {
+        execSync(command, {
+          encoding: 'utf-8',
+          timeout: 30_000,
+          stdio: ['pipe', 'pipe', 'pipe'],
+        });
+        succeeded = true;
+        break;
+      } catch (err) {
+        const reason = err instanceof Error ? err.message.split('\n')[0] : String(err);
+        if (attempt < PROBE_MAX_RETRIES && TRANSIENT_PATTERNS.test(reason)) {
+          console.warn(`    ${id}: transient failure (attempt ${attempt}/${PROBE_MAX_RETRIES}) — ${reason}`);
+          continue;
+        }
+        console.warn(`    ${id}: unavailable — ${reason}`);
+        break;
+      }
+    }
+
+    if (succeeded) {
       valid.push(id);
       console.log(`    ${id}: available`);
-    } catch (err) {
-      const reason = err instanceof Error ? err.message.split('\n')[0] : String(err);
-      console.warn(`    ${id}: unavailable — ${reason}`);
     }
   }
 

--- a/tests/refreshCatalog.test.ts
+++ b/tests/refreshCatalog.test.ts
@@ -335,13 +335,32 @@ describe('probeModels', () => {
     expect(mockExecSync).toHaveBeenCalledTimes(3);
   });
 
-  it('filters out models that fail probing', () => {
+  it('filters out models that fail probing with non-transient errors', () => {
     mockExecSync
       .mockReturnValueOnce('OK')           // model-a: success
-      .mockImplementationOnce(() => { throw new Error('model not found'); }) // model-b: fail
+      .mockImplementationOnce(() => { throw new Error('model not found'); }) // model-b: fail (no retry)
       .mockReturnValueOnce('OK');           // model-c: success
     const result = probeModels(fakeConfig, ['model-a', 'model-b', 'model-c']);
     expect(result).toEqual(['model-a', 'model-c']);
+    // model-b should only be attempted once (non-transient error)
+    expect(mockExecSync).toHaveBeenCalledTimes(3);
+  });
+
+  it('retries on transient errors and succeeds', () => {
+    mockExecSync
+      .mockImplementationOnce(() => { throw new Error('spawnSync /bin/sh ETIMEDOUT'); }) // attempt 1: timeout
+      .mockImplementationOnce(() => { throw new Error('socket hang up'); })              // attempt 2: network
+      .mockReturnValueOnce('OK');                                                         // attempt 3: success
+    const result = probeModels(fakeConfig, ['model-a']);
+    expect(result).toEqual(['model-a']);
+    expect(mockExecSync).toHaveBeenCalledTimes(3);
+  });
+
+  it('gives up after max retries on persistent transient errors', () => {
+    mockExecSync.mockImplementation(() => { throw new Error('spawnSync /bin/sh ETIMEDOUT'); });
+    const result = probeModels(fakeConfig, ['model-a']);
+    expect(result).toEqual([]);
+    expect(mockExecSync).toHaveBeenCalledTimes(3); // 3 attempts then give up
   });
 
   it('returns empty array when all probes fail', () => {


### PR DESCRIPTION
## Summary
- Probe phase now retries up to 3 times on transient errors (timeouts, network resets, rate limits)
- Non-transient errors (e.g., "model does not exist") fail immediately without retrying
- Fixes `gemini-2.5-pro` being incorrectly excluded due to a one-off `ETIMEDOUT` during probing

## Test plan
- [x] 201 tests pass (2 new retry-specific tests)
- [ ] Trigger `refresh-catalog.yml` via `workflow_dispatch` after merge

🤖 Generated with Claude, Codex, and Gemini