### PR TITLE
Add forensic logging and managed HTTP service

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,17 @@ OpenCode: "I checked with three providers. They all agree with Codex."
 
 ---
 
-## One-Line Install
+## One-Line Install (macOS / Linux)
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/osanoai/multicli/main/install.sh | bash
 ```
 
-Detects which AI CLIs you have installed and configures Multi-CLI for all of them automatically. No config files, no API keys, no environment variables. If it's on your PATH, it works.
+Detects which AI CLIs you have installed and configures Multi-CLI for them automatically.
+
+- Claude Code is configured to use a per-user local HTTP service on `127.0.0.1`
+- Gemini CLI, Codex CLI, and OpenCode keep using stdio/local config by default
+- The installer may update client config files on your behalf
 
 ---
 
@@ -47,7 +51,7 @@ This tool was built by the very AIs it connects.
 
 Claude, Gemini, Codex, and OpenCode wrote the code. Claude, Gemini, Codex, and OpenCode maintain it. Every night, a CI job queries the latest stable release of each CLI for its current model list, diffs the results against what's in the repo, and automatically publishes a new version if anything changed. New model releases get picked up within 24 hours. Deprecated models get cleaned out. The repo stays current without anyone touching it.
 
-Because all install commands use `@latest`, your MCP client pulls the newest version every time it starts — no manual updates, no stale model lists, no maintenance.
+The stdio install paths use `@latest`, so those clients pick up new releases automatically. Claude Code's managed HTTP service intentionally runs from a stable installed runtime instead of a transient `npx` cache; rerun the installer or `multicli service refresh --configure-claude` after upgrading.
 
 Most MCP tools go stale within weeks. This one is self-maintaining by design.
 
@@ -55,7 +59,7 @@ Most MCP tools go stale within weeks. This one is self-maintaining by design.
 
 ## Prerequisites
 
-You need **Node.js >= 20** and at least **two** of these CLIs installed:
+You need **Node.js >= 20** and at least **one** of these CLIs installed:
 
 | CLI | Install |
 |-----|---------|
@@ -64,7 +68,7 @@ You need **Node.js >= 20** and at least **two** of these CLIs installed:
 | [Codex CLI](https://github.com/openai/codex) | `npm install -g @openai/codex` |
 | [OpenCode](https://opencode.ai) | `curl -fsSL https://opencode.ai/install | bash` |
 
-> Why two? Because one AI talking to itself is a monologue, not a collaboration.
+> Multi-CLI is most useful with two or more CLIs installed. With only one, the install still works, but there may be nothing to bridge yet.
 
 ---
 
@@ -73,6 +77,35 @@ You need **Node.js >= 20** and at least **two** of these CLIs installed:
 Prefer to install per-client yourself? Each command is one line.
 
 ### Claude Code
+
+Recommended for Claude Code stability:
+
+```bash
+npm install -g @osanoai/multicli
+multicli service install --configure-claude
+```
+
+This installs a per-user background service that listens only on `127.0.0.1`, configures Claude Code to use Multi-CLI over HTTP, and keeps the underlying server alive even if Claude drops a stdio subprocess.
+
+The managed service installs as a per-user login/background service:
+
+- macOS: `launchd` LaunchAgent
+- Ubuntu/Debian: `systemd --user`
+- Windows: Scheduled Task at user logon
+
+Security model:
+
+- Listens only on `127.0.0.1`
+- Uses `Authorization: Bearer <token>` for every HTTP MCP request
+- Stores generated service artifacts in a user-owned service directory
+
+Operational notes:
+
+- `multicli service install` refuses transient `npx` runtimes; use a global install or a stable local checkout
+- Generated service state includes an env file you can edit if your local AI CLIs require additional credentials or PATH entries
+- On Linux, the default `systemd --user` service follows your login session; enable `linger` yourself only if you intentionally want it to stay up after logout
+
+Legacy stdio installation is still available:
 
 ```bash
 claude mcp add --scope user Multi-CLI -- npx -y @osanoai/multicli@latest
@@ -172,11 +205,21 @@ If the file already exists, merge the `"Multi-CLI"` entry into the existing `"mc
 
 ### Any Other MCP Client
 
-Multi-CLI uses standard stdio transport. If your client supports MCP, point it at:
+Multi-CLI supports both stdio and Streamable HTTP.
+
+For stdio-capable clients, point them at:
 
 ```
 npx -y @osanoai/multicli@latest
 ```
+
+For a managed local HTTP service, install Multi-CLI globally and run:
+
+```bash
+multicli service install
+```
+
+The service listens on `127.0.0.1` only and exposes `/mcp` plus `/health`.
 
 ---
 
@@ -247,6 +290,15 @@ Or get a second opinion on anything:
 5. Results flow back through MCP to your AI client
 ```
 
+For Claude Code, Multi-CLI can also run as a local background HTTP service:
+
+```
+┌─────────────┐     MCP (HTTP)       ┌──────────────┐     CLI calls    ┌─────────────┐
+│ Claude Code │ ◄──────────────────► │  Multi-CLI   │ ───────────────► │ Other AIs   │
+│   Client    │    127.0.0.1 only    │   service    │                  │ (CLI tools) │
+└─────────────┘                      └──────────────┘                  └─────────────┘
+```
+
 ---
 
 ## Troubleshooting
@@ -262,17 +314,48 @@ If only your own CLI is installed, Multi-CLI hides it (no self-calls). Install a
 
 **MCP server not responding?**
 1. Check that Node.js >= 20 is installed
-2. Run `npx @osanoai/multicli@latest` directly to see if it starts
+2. Run `npx -y @osanoai/multicli@latest` directly to see if the stdio server starts
 3. Restart your AI client completely
+
+**Claude Code disconnecting after successful calls?**
+Use the managed background service instead of the legacy stdio integration:
+
+```bash
+npm install -g @osanoai/multicli
+multicli service install --configure-claude
+multicli service doctor
+```
+
+Helpful service commands:
+
+- `multicli service status`
+- `multicli service doctor`
+- `multicli service logs`
+- `multicli service refresh`
+- `multicli service uninstall`
 
 **Need to tune timeouts or cleanup behavior?**
 Multi-CLI supports these optional environment variables:
 
+- `MULTICLI_TRANSPORT` (`stdio` or `http`)
 - `MULTICLI_ASK_TIMEOUT_MS`
 - `MULTICLI_HELP_TIMEOUT_MS`
 - `MULTICLI_CLI_DETECT_TIMEOUT_MS`
 - `MULTICLI_KILL_GRACE_MS`
-- `MULTICLI_LOG_LEVEL` (`error`, `info`, or `debug`)
+- `MULTICLI_HTTP_HOST` (defaults to `127.0.0.1`)
+- `MULTICLI_HTTP_PORT` (defaults to `37420`)
+- `MULTICLI_HTTP_PATH` (defaults to `/mcp`)
+- `MULTICLI_HTTP_AUTH_TOKEN` (required for direct HTTP mode)
+- `MULTICLI_HTTP_SESSION_IDLE_MS`
+- `MULTICLI_LOG_PATH` (defaults to `~/.multicli/logs/multicli.log`)
+- `MULTICLI_LOG_LEVEL` (`error`, `info`, or `debug`; defaults to `debug` for the file log)
+- `MULTICLI_STDERR_LOG_LEVEL` (`silent`, `error`, `info`, or `debug`; defaults to `error`)
+- `MULTICLI_SERVICE_ROOT_DIR`
+- `MULTICLI_SERVICE_LOG_PATH`
+- `MULTICLI_SERVICE_ENV_PATH`
+- `MULTICLI_SERVICE_RUNTIME_PATH`
+
+The server writes structured JSON-line logs to a single file destination, rotates them automatically for long-running service mode, and includes full prompt bodies for `Ask-*` requests so disconnects and crashes can be reconstructed after the fact.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ Multi-CLI supports these optional environment variables:
 - `MULTICLI_SERVICE_ROOT_DIR`
 - `MULTICLI_SERVICE_LOG_PATH`
 - `MULTICLI_SERVICE_ENV_PATH`
-- `MULTICLI_SERVICE_RUNTIME_PATH`
+- `MULTICLI_SERVICE_MANIFEST_PATH`
 
 The server writes structured JSON-line logs to a single file destination, rotates them automatically for long-running service mode, and includes full prompt bodies for `Ask-*` requests so disconnects and crashes can be reconstructed after the fact.
 

--- a/install.sh
+++ b/install.sh
@@ -11,6 +11,9 @@ RESET='\033[0m'
 
 PACKAGE="@osanoai/multicli@latest"
 SERVER_NAME="Multi-CLI"
+GLOBAL_PACKAGE="@osanoai/multicli@latest"
+GLOBAL_MULTICLI_ENTRY=""
+GLOBAL_INSTALL_READY=false
 
 echo ""
 echo -e "${CYAN}${BOLD}  Multi-CLI MCP Installer${RESET}"
@@ -27,6 +30,36 @@ command -v claude   &>/dev/null && CLAUDE_FOUND=true
 command -v gemini   &>/dev/null && GEMINI_FOUND=true
 command -v codex    &>/dev/null && CODEX_FOUND=true
 command -v opencode &>/dev/null && OPENCODE_FOUND=true
+
+install_global_multicli() {
+  if $GLOBAL_INSTALL_READY; then
+    return 0
+  fi
+
+  if ! command -v npm &>/dev/null; then
+    echo -e "${YELLOW}  npm is required to install the managed Claude Code service.${RESET}"
+    return 1
+  fi
+
+  echo -e "  ${CYAN}→ Installing stable Multi-CLI runtime for Claude Code...${RESET}"
+  if ! npm install -g "$GLOBAL_PACKAGE" >/dev/null 2>&1; then
+    return 1
+  fi
+
+  local npm_root
+  npm_root="$(npm root -g 2>/dev/null || true)"
+  if [ -z "$npm_root" ]; then
+    return 1
+  fi
+
+  GLOBAL_MULTICLI_ENTRY="$npm_root/@osanoai/multicli/dist/index.js"
+  if [ ! -f "$GLOBAL_MULTICLI_ENTRY" ]; then
+    return 1
+  fi
+
+  GLOBAL_INSTALL_READY=true
+  return 0
+}
 
 FOUND_COUNT=0
 $CLAUDE_FOUND   && ((FOUND_COUNT++)) || true
@@ -55,7 +88,7 @@ FAILED=()
 
 if $CLAUDE_FOUND; then
   echo -e "  ${CYAN}→ Installing for Claude Code...${RESET}"
-  if claude mcp add --scope user "$SERVER_NAME" -- npx -y "$PACKAGE" 2>/dev/null; then
+  if install_global_multicli && node "$GLOBAL_MULTICLI_ENTRY" service install --configure-claude >/dev/null 2>&1; then
     INSTALLED+=("Claude Code")
   else
     FAILED+=("Claude Code")
@@ -120,6 +153,12 @@ if [ "${#FAILED[@]}" -gt 0 ]; then
   for cli in "${FAILED[@]}"; do
     echo -e "  ${YELLOW}• $cli${RESET}"
   done
+  if [[ " ${FAILED[*]} " == *" Claude Code "* ]]; then
+    echo ""
+    echo "  Claude Code manual fallback:"
+    echo "    npm install -g @osanoai/multicli"
+    echo "    multicli service install --configure-claude"
+  fi
   echo ""
 fi
 
@@ -137,7 +176,7 @@ if [ "$FOUND_COUNT" -eq 1 ]; then
   echo ""
   echo -e "${YELLOW}${BOLD}  ⚠  Warning: only one AI CLI detected.${RESET}"
   echo -e "${YELLOW}  Multi-CLI is a collaboration tool — it bridges multiple AIs together.${RESET}"
-  echo -e "${YELLOW}  With only ${INSTALLED[0]} installed, there's nothing to bridge to.${RESET}"
+  echo -e "${YELLOW}  With only ${INSTALLED[0]} installed, there may be nothing to bridge to yet.${RESET}"
   echo ""
   echo "  Install at least one more CLI to unlock cross-model collaboration:"
   $CLAUDE_FOUND   || echo "    • Claude Code  →  npm install -g @anthropic-ai/claude-code"
@@ -154,6 +193,6 @@ else
   done
   echo ""
   echo -e "  Restart your AI client and the cross-model tools will appear automatically."
-  echo -e "  No config. No API keys. No setup. Just works."
+  echo -e "  Claude Code now uses the managed local HTTP service; other detected clients keep their stdio/local configuration."
   echo ""
 fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@osanoai/multicli",
       "version": "1.5.37",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.27.1",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "dotenv": "^17.3.1",
         "zod": "^4.3.6"
       },
@@ -17,10 +17,10 @@
       },
       "devDependencies": {
         "@types/node": "^25.3.3",
-        "@vitest/coverage-v8": "^4.0.18",
+        "@vitest/coverage-v8": "^4.1.5",
         "husky": "^9.1.7",
         "typescript": "^5.9.3",
-        "vitest": "^4.0.18"
+        "vitest": "^4.1.5"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -86,452 +86,44 @@
         "node": ">=18"
       }
     },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
-      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
-      "cpu": [
-        "ppc64"
-      ],
+    "node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
       }
     },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
-      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
-      "cpu": [
-        "arm"
-      ],
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
-      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
-      "cpu": [
-        "arm64"
-      ],
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
-      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
-      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
-      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
-      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
-      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
-      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
-      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
-      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
-      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
-      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
-      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
-      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
-      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
-      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
-      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
-      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
-      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
-      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
-      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
-      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.9",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
-      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -569,9 +161,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
-      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",
@@ -608,24 +200,39 @@
         }
       }
     },
-    "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
-      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
-      "cpu": [
-        "arm"
-      ],
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "android"
-      ]
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
     },
-    "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
-      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
+    "node_modules/@oxc-project/types": {
+      "version": "0.126.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.126.0.tgz",
+      "integrity": "sha512-oGfVtjAgwQVVpfBrbtk4e1XDyWHRFta6BS3GWVzrF8xYBT2VGQAk39yJS/wFSMrZqoiCU4oghT3Ch0HaHGIHcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.16.tgz",
+      "integrity": "sha512-rhY3k7Bsae9qQfOtph2Pm2jZEA+s8Gmjoz4hhmx70K9iMQ/ddeae+xhRQcM5IuVx5ry1+bGfkvMn7D6MJggVSA==",
       "cpu": [
         "arm64"
       ],
@@ -634,12 +241,15 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
-      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.16.tgz",
+      "integrity": "sha512-rNz0yK078yrNn3DrdgN+PKiMOW8HfQ92jQiXxwX8yW899ayV00MLVdaCNeVBhG/TbH3ouYVObo8/yrkiectkcQ==",
       "cpu": [
         "arm64"
       ],
@@ -648,12 +258,15 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
-      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.16.tgz",
+      "integrity": "sha512-r/OmdR00HmD4i79Z//xO06uEPOq5hRXdhw7nzkxQxwSavs3PSHa1ijntdpOiZ2mzOQ3fVVu8C1M19FoNM+dMUQ==",
       "cpu": [
         "x64"
       ],
@@ -662,26 +275,15 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
-      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
-      "cpu": [
-        "arm64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
-      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.16.tgz",
+      "integrity": "sha512-KcRE5w8h0OnjUatG8pldyD14/CQ5Phs1oxfR+3pKDjboHRo9+MkqQaiIZlZRpsxC15paeXme/I127tUa9TXJ6g==",
       "cpu": [
         "x64"
       ],
@@ -690,12 +292,15 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
-      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.16.tgz",
+      "integrity": "sha512-bT0guA1bpxEJ/ZhTRniQf7rNF8ybvXOuWbNIeLABaV5NGjx4EtOWBTSRGWFU9ZWVkPOZ+HNFP8RMcBokBiZ0Kg==",
       "cpu": [
         "arm"
       ],
@@ -704,26 +309,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
-      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
-      "cpu": [
-        "arm"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
-      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.16.tgz",
+      "integrity": "sha512-+tHktCHWV8BDQSjemUqm/Jl/TPk3QObCTIjmdDy/nlupcujZghmKK2962LYrqFpWu+ai01AN/REOH3NEpqvYQg==",
       "cpu": [
         "arm64"
       ],
@@ -732,12 +326,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
-      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.16.tgz",
+      "integrity": "sha512-3fPzdREH806oRLxpTWW1Gt4tQHs0TitZFOECB2xzCFLPKnSOy90gwA7P29cksYilFO6XVRY1kzga0cL2nRjKPg==",
       "cpu": [
         "arm64"
       ],
@@ -746,40 +343,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
-      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
-      "cpu": [
-        "loong64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
-      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
-      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.16.tgz",
+      "integrity": "sha512-EKwI1tSrLs7YVw+JPJT/G2dJQ1jl9qlTTTEG0V2Ok/RdOenRfBw2PQdLPyjhIu58ocdBfP7vIRN/pvMsPxs/AQ==",
       "cpu": [
         "ppc64"
       ],
@@ -788,54 +360,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
-      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
-      "cpu": [
-        "ppc64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
-      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
-      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
-      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.16.tgz",
+      "integrity": "sha512-Uknladnb3Sxqu6SEcqBldQyJUpk8NleooZEc0MbRBJ4inEhRYWZX0NJu12vNf2mqAq7gsofAxHrGghiUYjhaLQ==",
       "cpu": [
         "s390x"
       ],
@@ -844,12 +377,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
-      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.16.tgz",
+      "integrity": "sha512-FIb8+uG49sZBtLTn+zt1AJ20TqVcqWeSIyoVt0or7uAWesgKaHbiBh6OpA/k9v0LTt+PTrb1Lao133kP4uVxkg==",
       "cpu": [
         "x64"
       ],
@@ -858,12 +394,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
-      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.16.tgz",
+      "integrity": "sha512-RuERhF9/EgWxZEXYWCOaViUWHIboceK4/ivdtQ3R0T44NjLkIIlGIAVAuCddFxsZ7vnRHtNQUrt2vR2n2slB2w==",
       "cpu": [
         "x64"
       ],
@@ -872,26 +411,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
-      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
-      "cpu": [
-        "x64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
-      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.16.tgz",
+      "integrity": "sha512-mXcXnvd9GpazCxeUCCnZ2+YF7nut+ZOEbE4GtaiPtyY6AkhZWbK70y1KK3j+RDhjVq5+U8FySkKRb/+w0EeUwA==",
       "cpu": [
         "arm64"
       ],
@@ -900,12 +428,34 @@
       "optional": true,
       "os": [
         "openharmony"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
-      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.16.tgz",
+      "integrity": "sha512-3Q2KQxnC8IJOLqXmUMoYwyIPZU9hzRbnHaoV3Euz+VVnjZKcY8ktnNP8T9R4/GGQtb27C/UYKABxesKWb8lsvQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.9.2",
+        "@emnapi/runtime": "1.9.2",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.16.tgz",
+      "integrity": "sha512-tj7XRemQcOcFwv7qhpUxMTBbI5mWMlE4c1Omhg5+h8GuLXzyj8HviYgR+bB2DMDgRqUE+jiDleqSCRjx4aYk/Q==",
       "cpu": [
         "arm64"
       ],
@@ -914,26 +464,15 @@
       "optional": true,
       "os": [
         "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
-      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
-      "cpu": [
-        "ia32"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
-      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.16.tgz",
+      "integrity": "sha512-PH5DRZT+F4f2PTXRXR8uJxnBq2po/xFtddyabTJVJs/ZYVHqXPEgNIr35IHTEa6bpa0Q8Awg+ymkTaGnKITw4g==",
       "cpu": [
         "x64"
       ],
@@ -942,21 +481,17 @@
       "optional": true,
       "os": [
         "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
-      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
-      "cpu": [
-        "x64"
       ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.16.tgz",
+      "integrity": "sha512-45+YtqxLYKDWQouLKCrpIZhke+nXxhsw+qAHVzHDVwttyBlHNBVs2K25rDXrZzhpTp9w1FlAlvweV1H++fdZoA==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
+      "license": "MIT"
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -964,6 +499,17 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -1001,29 +547,29 @@
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.0.18.tgz",
-      "integrity": "sha512-7i+N2i0+ME+2JFZhfuz7Tg/FqKtilHjGyGvoHYQ6iLV0zahbsJ9sljC9OcFcPDbhYKCet+sG8SsVqlyGvPflZg==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.5.tgz",
+      "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.0.18",
-        "ast-v8-to-istanbul": "^0.3.10",
+        "@vitest/utils": "4.1.5",
+        "ast-v8-to-istanbul": "^1.0.0",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
         "istanbul-reports": "^3.2.0",
-        "magicast": "^0.5.1",
+        "magicast": "^0.5.2",
         "obug": "^2.1.1",
-        "std-env": "^3.10.0",
-        "tinyrainbow": "^3.0.3"
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "4.0.18",
-        "vitest": "4.0.18"
+        "@vitest/browser": "4.1.5",
+        "vitest": "4.1.5"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -1032,44 +578,71 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
-      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.0.18",
-        "@vitest/utils": "4.0.18",
-        "chai": "^6.2.1",
-        "tinyrainbow": "^3.0.3"
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/@vitest/pretty-format": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
-      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^3.0.3"
+        "@vitest/spy": "4.1.5",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
-      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.0.18",
+        "@vitest/utils": "4.1.5",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -1077,13 +650,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
-      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.18",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -1092,9 +666,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
-      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1102,14 +676,15 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
-      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.18",
-        "tinyrainbow": "^3.0.3"
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -1172,25 +747,15 @@
       }
     },
     "node_modules/ast-v8-to-istanbul": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
-      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.31",
         "estree-walker": "^3.0.3",
         "js-tokens": "^10.0.0"
-      }
-    },
-    "node_modules/ast-v8-to-istanbul/node_modules/estree-walker": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0"
       }
     },
     "node_modules/body-parser": {
@@ -1303,6 +868,13 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cookie": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
@@ -1378,6 +950,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/dotenv": {
       "version": "17.3.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
@@ -1438,9 +1020,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1456,53 +1038,21 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/esbuild": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
-      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.3",
-        "@esbuild/android-arm": "0.27.3",
-        "@esbuild/android-arm64": "0.27.3",
-        "@esbuild/android-x64": "0.27.3",
-        "@esbuild/darwin-arm64": "0.27.3",
-        "@esbuild/darwin-x64": "0.27.3",
-        "@esbuild/freebsd-arm64": "0.27.3",
-        "@esbuild/freebsd-x64": "0.27.3",
-        "@esbuild/linux-arm": "0.27.3",
-        "@esbuild/linux-arm64": "0.27.3",
-        "@esbuild/linux-ia32": "0.27.3",
-        "@esbuild/linux-loong64": "0.27.3",
-        "@esbuild/linux-mips64el": "0.27.3",
-        "@esbuild/linux-ppc64": "0.27.3",
-        "@esbuild/linux-riscv64": "0.27.3",
-        "@esbuild/linux-s390x": "0.27.3",
-        "@esbuild/linux-x64": "0.27.3",
-        "@esbuild/netbsd-arm64": "0.27.3",
-        "@esbuild/netbsd-x64": "0.27.3",
-        "@esbuild/openbsd-arm64": "0.27.3",
-        "@esbuild/openbsd-x64": "0.27.3",
-        "@esbuild/openharmony-arm64": "0.27.3",
-        "@esbuild/sunos-x64": "0.27.3",
-        "@esbuild/win32-arm64": "0.27.3",
-        "@esbuild/win32-ia32": "0.27.3",
-        "@esbuild/win32-x64": "0.27.3"
-      }
-    },
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
     },
     "node_modules/etag": {
       "version": "1.8.1",
@@ -1792,9 +1342,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.7",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.7.tgz",
-      "integrity": "sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==",
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -1945,6 +1495,267 @@
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -2145,9 +1956,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -2191,9 +2002,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
         {
@@ -2296,49 +2107,38 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/rollup": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
-      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.16.tgz",
+      "integrity": "sha512-rzi5WqKzEZw3SooTt7cgm4eqIoujPIyGcJNGFL7iPEuajQw7vxMHUkXylu4/vhCkJGXsgRmxqMKXUpT6FEgl0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.8"
+        "@oxc-project/types": "=0.126.0",
+        "@rolldown/pluginutils": "1.0.0-rc.16"
       },
       "bin": {
-        "rollup": "dist/bin/rollup"
+        "rolldown": "bin/cli.mjs"
       },
       "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.59.0",
-        "@rollup/rollup-android-arm64": "4.59.0",
-        "@rollup/rollup-darwin-arm64": "4.59.0",
-        "@rollup/rollup-darwin-x64": "4.59.0",
-        "@rollup/rollup-freebsd-arm64": "4.59.0",
-        "@rollup/rollup-freebsd-x64": "4.59.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
-        "@rollup/rollup-linux-arm64-musl": "4.59.0",
-        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
-        "@rollup/rollup-linux-loong64-musl": "4.59.0",
-        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
-        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
-        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
-        "@rollup/rollup-linux-x64-gnu": "4.59.0",
-        "@rollup/rollup-linux-x64-musl": "4.59.0",
-        "@rollup/rollup-openbsd-x64": "4.59.0",
-        "@rollup/rollup-openharmony-arm64": "4.59.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
-        "@rollup/rollup-win32-x64-gnu": "4.59.0",
-        "@rollup/rollup-win32-x64-msvc": "4.59.0",
-        "fsevents": "~2.3.2"
+        "@rolldown/binding-android-arm64": "1.0.0-rc.16",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.16",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.16",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.16",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.16",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.16",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.16",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.16",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.16",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.16",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.16",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.16",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.16",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.16",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.16"
       }
     },
     "node_modules/router": {
@@ -2554,9 +2354,9 @@
       }
     },
     "node_modules/std-env": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
-      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -2581,9 +2381,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
-      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2591,14 +2391,14 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -2608,9 +2408,9 @@
       }
     },
     "node_modules/tinyrainbow": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
-      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2625,6 +2425,14 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/type-is": {
       "version": "2.0.1",
@@ -2679,134 +2487,18 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/vitest": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
-      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+    "node_modules/vite": {
+      "version": "8.0.9",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.9.tgz",
+      "integrity": "sha512-t7g7GVRpMXjNpa67HaVWI/8BWtdVIQPCL2WoozXXA7LBGEFK4AkkKkHx2hAQf5x1GZSlcmEDPkVLSGahxnEEZw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.0.18",
-        "@vitest/mocker": "4.0.18",
-        "@vitest/pretty-format": "4.0.18",
-        "@vitest/runner": "4.0.18",
-        "@vitest/snapshot": "4.0.18",
-        "@vitest/spy": "4.0.18",
-        "@vitest/utils": "4.0.18",
-        "es-module-lexer": "^1.7.0",
-        "expect-type": "^1.2.2",
-        "magic-string": "^0.30.21",
-        "obug": "^2.1.1",
-        "pathe": "^2.0.3",
-        "picomatch": "^4.0.3",
-        "std-env": "^3.10.0",
-        "tinybench": "^2.9.0",
-        "tinyexec": "^1.0.2",
-        "tinyglobby": "^0.2.15",
-        "tinyrainbow": "^3.0.3",
-        "vite": "^6.0.0 || ^7.0.0",
-        "why-is-node-running": "^2.3.0"
-      },
-      "bin": {
-        "vitest": "vitest.mjs"
-      },
-      "engines": {
-        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "@edge-runtime/vm": "*",
-        "@opentelemetry/api": "^1.9.0",
-        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.0.18",
-        "@vitest/browser-preview": "4.0.18",
-        "@vitest/browser-webdriverio": "4.0.18",
-        "@vitest/ui": "4.0.18",
-        "happy-dom": "*",
-        "jsdom": "*"
-      },
-      "peerDependenciesMeta": {
-        "@edge-runtime/vm": {
-          "optional": true
-        },
-        "@opentelemetry/api": {
-          "optional": true
-        },
-        "@types/node": {
-          "optional": true
-        },
-        "@vitest/browser-playwright": {
-          "optional": true
-        },
-        "@vitest/browser-preview": {
-          "optional": true
-        },
-        "@vitest/browser-webdriverio": {
-          "optional": true
-        },
-        "@vitest/ui": {
-          "optional": true
-        },
-        "happy-dom": {
-          "optional": true
-        },
-        "jsdom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vitest/node_modules/@vitest/mocker": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
-      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/spy": "4.0.18",
-        "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.21"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "msw": "^2.4.9",
-        "vite": "^6.0.0 || ^7.0.0-0"
-      },
-      "peerDependenciesMeta": {
-        "msw": {
-          "optional": true
-        },
-        "vite": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vitest/node_modules/estree-walker": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0"
-      }
-    },
-    "node_modules/vitest/node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "esbuild": "^0.27.0",
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.3",
-        "postcss": "^8.5.6",
-        "rollup": "^4.43.0",
-        "tinyglobby": "^0.2.15"
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.10",
+        "rolldown": "1.0.0-rc.16",
+        "tinyglobby": "^0.2.16"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -2822,9 +2514,10 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
-        "lightningcss": "^1.21.0",
         "sass": "^1.70.0",
         "sass-embedded": "^1.70.0",
         "stylus": ">=0.54.8",
@@ -2837,13 +2530,16 @@
         "@types/node": {
           "optional": true
         },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
         "jiti": {
           "optional": true
         },
         "less": {
-          "optional": true
-        },
-        "lightningcss": {
           "optional": true
         },
         "sass": {
@@ -2866,6 +2562,96 @@
         },
         "yaml": {
           "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -47,18 +47,21 @@
     "README.md"
   ],
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.27.1",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "dotenv": "^17.3.1",
     "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/node": "^25.3.3",
-    "@vitest/coverage-v8": "^4.0.18",
+    "@vitest/coverage-v8": "^4.1.5",
     "husky": "^9.1.7",
     "typescript": "^5.9.3",
-    "vitest": "^4.0.18"
+    "vitest": "^4.1.5"
   },
   "overrides": {
+    "@hono/node-server": "^1.19.14",
+    "hono": "^4.12.14",
+    "path-to-regexp": "^8.4.2",
     "picomatch": "^4.0.4"
   },
   "publishConfig": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -46,7 +46,7 @@ export interface MultiCliConfig {
   serviceRootDir: string;
   serviceLogPath: string;
   serviceEnvPath: string;
-  serviceRuntimePath: string;
+  serviceManifestPath: string;
 }
 
 const DEFAULTS: MultiCliConfig = {
@@ -70,7 +70,7 @@ const DEFAULTS: MultiCliConfig = {
   serviceRootDir: getDefaultServiceRootDir(),
   serviceLogPath: path.join(getDefaultServiceRootDir(), 'logs', 'service.log'),
   serviceEnvPath: path.join(getDefaultServiceRootDir(), 'env'),
-  serviceRuntimePath: path.join(getDefaultServiceRootDir(), 'runtime.json'),
+  serviceManifestPath: path.join(getDefaultServiceRootDir(), 'manifest.json'),
 };
 
 function parsePositiveInt(
@@ -191,9 +191,9 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): MultiCliConfig
       env.MULTICLI_SERVICE_ENV_PATH,
       path.join(serviceRootDir, 'env'),
     ),
-    serviceRuntimePath: parseString(
-      env.MULTICLI_SERVICE_RUNTIME_PATH,
-      path.join(serviceRootDir, 'runtime.json'),
+    serviceManifestPath: parseString(
+      env.MULTICLI_SERVICE_MANIFEST_PATH ?? env.MULTICLI_SERVICE_RUNTIME_PATH,
+      path.join(serviceRootDir, 'manifest.json'),
     ),
   };
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,32 @@
+import os from 'node:os';
+import path from 'node:path';
+
 export type MultiCliLogLevel = 'error' | 'info' | 'debug';
+export type MultiCliStderrLogLevel = MultiCliLogLevel | 'silent';
+export type MultiCliTransport = 'stdio' | 'http';
+
+function getDefaultServiceRootDir(
+  platform: NodeJS.Platform = process.platform,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  switch (platform) {
+    case 'darwin':
+      return path.join(os.homedir(), 'Library', 'Application Support', 'MultiCLI');
+    case 'win32':
+      return path.join(
+        env.LOCALAPPDATA ?? path.join(os.homedir(), 'AppData', 'Local'),
+        'MultiCLI',
+      );
+    default:
+      return path.join(
+        env.XDG_CONFIG_HOME ?? path.join(os.homedir(), '.config'),
+        'multicli',
+      );
+  }
+}
 
 export interface MultiCliConfig {
+  transport: MultiCliTransport;
   askTimeoutMs: number;
   helpTimeoutMs: number;
   cliDetectTimeoutMs: number;
@@ -9,10 +35,22 @@ export interface MultiCliConfig {
   taskPollIntervalMs: number;
   progressIdleHeartbeatMs: number;
   progressThrottleMs: number;
+  httpHost: string;
+  httpPort: number;
+  httpPath: string;
+  httpAuthToken?: string;
+  httpSessionIdleMs: number;
+  logPath: string;
   logLevel: MultiCliLogLevel;
+  stderrLogLevel: MultiCliStderrLogLevel;
+  serviceRootDir: string;
+  serviceLogPath: string;
+  serviceEnvPath: string;
+  serviceRuntimePath: string;
 }
 
 const DEFAULTS: MultiCliConfig = {
+  transport: 'stdio',
   askTimeoutMs: 15 * 60 * 1000,
   helpTimeoutMs: 30 * 1000,
   cliDetectTimeoutMs: 5 * 1000,
@@ -21,7 +59,18 @@ const DEFAULTS: MultiCliConfig = {
   taskPollIntervalMs: 1000,
   progressIdleHeartbeatMs: 10 * 1000,
   progressThrottleMs: 1000,
-  logLevel: 'error',
+  httpHost: '127.0.0.1',
+  httpPort: 37420,
+  httpPath: '/mcp',
+  httpAuthToken: undefined,
+  httpSessionIdleMs: 30 * 60 * 1000,
+  logPath: path.join(os.homedir(), '.multicli', 'logs', 'multicli.log'),
+  logLevel: 'debug',
+  stderrLogLevel: 'error',
+  serviceRootDir: getDefaultServiceRootDir(),
+  serviceLogPath: path.join(getDefaultServiceRootDir(), 'logs', 'service.log'),
+  serviceEnvPath: path.join(getDefaultServiceRootDir(), 'env'),
+  serviceRuntimePath: path.join(getDefaultServiceRootDir(), 'runtime.json'),
 };
 
 function parsePositiveInt(
@@ -52,8 +101,59 @@ function parseLogLevel(
   }
 }
 
+function parseTransport(
+  value: string | undefined,
+  fallback: MultiCliTransport,
+): MultiCliTransport {
+  switch (value) {
+    case 'stdio':
+    case 'http':
+      return value;
+    default:
+      return fallback;
+  }
+}
+
+function parseStderrLogLevel(
+  value: string | undefined,
+  fallback: MultiCliStderrLogLevel,
+): MultiCliStderrLogLevel {
+  switch (value) {
+    case 'error':
+    case 'info':
+    case 'debug':
+    case 'silent':
+      return value;
+    default:
+      return fallback;
+  }
+}
+
+function parseString(
+  value: string | undefined,
+  fallback: string,
+): string {
+  if (!value) {
+    return fallback;
+  }
+
+  const trimmed = value.trim();
+  return trimmed || fallback;
+}
+
+function normalizeHttpPath(value: string | undefined, fallback: string): string {
+  const parsed = parseString(value, fallback);
+  return parsed.startsWith('/') ? parsed : `/${parsed}`;
+}
+
 export function loadConfig(env: NodeJS.ProcessEnv = process.env): MultiCliConfig {
+  const serviceRootDir = parseString(
+    env.MULTICLI_SERVICE_ROOT_DIR,
+    DEFAULTS.serviceRootDir,
+  );
+
   return {
+    transport: parseTransport(env.MULTICLI_TRANSPORT, DEFAULTS.transport),
     askTimeoutMs: parsePositiveInt(env.MULTICLI_ASK_TIMEOUT_MS, DEFAULTS.askTimeoutMs),
     helpTimeoutMs: parsePositiveInt(env.MULTICLI_HELP_TIMEOUT_MS, DEFAULTS.helpTimeoutMs),
     cliDetectTimeoutMs: parsePositiveInt(env.MULTICLI_CLI_DETECT_TIMEOUT_MS, DEFAULTS.cliDetectTimeoutMs),
@@ -68,6 +168,32 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): MultiCliConfig
       env.MULTICLI_PROGRESS_THROTTLE_MS,
       DEFAULTS.progressThrottleMs,
     ),
+    httpHost: parseString(env.MULTICLI_HTTP_HOST, DEFAULTS.httpHost),
+    httpPort: parsePositiveInt(env.MULTICLI_HTTP_PORT, DEFAULTS.httpPort),
+    httpPath: normalizeHttpPath(env.MULTICLI_HTTP_PATH, DEFAULTS.httpPath),
+    httpAuthToken: env.MULTICLI_HTTP_AUTH_TOKEN?.trim() || DEFAULTS.httpAuthToken,
+    httpSessionIdleMs: parsePositiveInt(
+      env.MULTICLI_HTTP_SESSION_IDLE_MS,
+      DEFAULTS.httpSessionIdleMs,
+    ),
+    logPath: parseString(env.MULTICLI_LOG_PATH, DEFAULTS.logPath),
     logLevel: parseLogLevel(env.MULTICLI_LOG_LEVEL, DEFAULTS.logLevel),
+    stderrLogLevel: parseStderrLogLevel(
+      env.MULTICLI_STDERR_LOG_LEVEL,
+      DEFAULTS.stderrLogLevel,
+    ),
+    serviceRootDir,
+    serviceLogPath: parseString(
+      env.MULTICLI_SERVICE_LOG_PATH,
+      path.join(serviceRootDir, 'logs', 'service.log'),
+    ),
+    serviceEnvPath: parseString(
+      env.MULTICLI_SERVICE_ENV_PATH,
+      path.join(serviceRootDir, 'env'),
+    ),
+    serviceRuntimePath: parseString(
+      env.MULTICLI_SERVICE_RUNTIME_PATH,
+      path.join(serviceRootDir, 'runtime.json'),
+    ),
   };
 }

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -1,3 +1,6 @@
+import type { Logger } from './logger.js';
+import type { ListRootsResult } from '@modelcontextprotocol/sdk/types.js';
+
 export type ToolTimeoutClass = 'ask' | 'help' | 'none';
 
 export interface ToolExecutionContext {
@@ -5,6 +8,10 @@ export interface ToolExecutionContext {
   onProgress?: (newOutput: string) => void;
   timeoutMs?: number;
   killGraceMs?: number;
+  cwd?: string;
+  projectRoots?: ListRootsResult['roots'];
+  env?: NodeJS.ProcessEnv;
   requestId?: string | number;
   taskId?: string;
+  logger?: Logger;
 }

--- a/src/httpServer.ts
+++ b/src/httpServer.ts
@@ -1,0 +1,415 @@
+import { randomUUID, timingSafeEqual } from 'node:crypto';
+import type { Server as HttpServer } from 'node:http';
+
+import { createMcpExpressApp } from '@modelcontextprotocol/sdk/server/express.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
+
+import { loadConfig, type MultiCliConfig } from './config.js';
+import { createLogger, type Logger } from './logger.js';
+import {
+  createServerApp,
+  createServerRuntime,
+  resolveWorkingDirectoryFromRoots,
+  type MultiCliRuntime,
+  type MultiCliServerApp,
+  type MultiCliSessionContext,
+} from './serverApp.js';
+
+interface HttpSessionRecord {
+  readonly sessionId: string;
+  readonly app: MultiCliServerApp;
+  readonly transport: StreamableHTTPServerTransport;
+  readonly logger: Logger;
+  readonly sessionContext: MultiCliSessionContext;
+  lastActivityAt: number;
+  idleTimer?: NodeJS.Timeout;
+  closing: boolean;
+}
+
+export interface MultiCliHttpServer {
+  readonly config: MultiCliConfig;
+  readonly runtime: MultiCliRuntime;
+  readonly url: string;
+  readonly healthUrl: string;
+  close(reason?: string): Promise<void>;
+}
+
+function isLoopbackHost(host: string): boolean {
+  return host === '127.0.0.1' || host === 'localhost';
+}
+
+function validateHttpConfig(config: MultiCliConfig): void {
+  if (!isLoopbackHost(config.httpHost)) {
+    throw new Error(
+      `HTTP host must be loopback-only. Received "${config.httpHost}".`,
+    );
+  }
+
+  if (!config.httpPath.startsWith('/')) {
+    throw new Error(`HTTP path must start with "/". Received "${config.httpPath}".`);
+  }
+
+  if (!config.httpAuthToken?.trim()) {
+    throw new Error(
+      'HTTP auth token is required in HTTP mode. Set MULTICLI_HTTP_AUTH_TOKEN or install the managed service first.',
+    );
+  }
+}
+
+function safeEqual(left: string, right: string): boolean {
+  const leftBuffer = Buffer.from(left);
+  const rightBuffer = Buffer.from(right);
+  if (leftBuffer.length !== rightBuffer.length) {
+    return false;
+  }
+
+  return timingSafeEqual(leftBuffer, rightBuffer);
+}
+
+function createOriginValidationMiddleware(
+  logger: Logger,
+  host: string,
+) {
+  return (req: any, res: any, next: any) => {
+    const origin = req.headers.origin;
+    if (!origin) {
+      next();
+      return;
+    }
+
+    try {
+      const url = new URL(origin);
+      if (url.hostname === host || url.hostname === '127.0.0.1' || url.hostname === 'localhost') {
+        next();
+        return;
+      }
+    } catch (error) {
+      logger.error('http_origin_invalid', { origin, error });
+    }
+
+    logger.error('http_origin_rejected', { origin, host });
+    res.status(403).json({
+      jsonrpc: '2.0',
+      error: {
+        code: -32000,
+        message: 'Invalid Origin header',
+      },
+      id: null,
+    });
+  };
+}
+
+function createAuthMiddleware(
+  logger: Logger,
+  token: string,
+) {
+  return (req: any, res: any, next: any) => {
+    const header = req.headers.authorization;
+    if (!header?.startsWith('Bearer ')) {
+      logger.error('http_auth_missing', {
+        method: req.method,
+        path: req.path,
+      });
+      res.status(401).json({
+        jsonrpc: '2.0',
+        error: {
+          code: -32000,
+          message: 'Missing Authorization header',
+        },
+        id: null,
+      });
+      return;
+    }
+
+    const providedToken = header.slice('Bearer '.length);
+    if (!safeEqual(providedToken, token)) {
+      logger.error('http_auth_rejected', {
+        method: req.method,
+        path: req.path,
+      });
+      res.status(401).json({
+        jsonrpc: '2.0',
+        error: {
+          code: -32000,
+          message: 'Invalid Authorization header',
+        },
+        id: null,
+      });
+      return;
+    }
+
+    next();
+  };
+}
+
+export async function startHttpServer(
+  config: MultiCliConfig = loadConfig(),
+  rootLogger: Logger = createLogger({
+    filePath: config.logPath,
+    fileLevel: config.logLevel,
+    stderrLevel: config.stderrLogLevel,
+    bindings: { component: 'multicli' },
+  }),
+  runtime?: MultiCliRuntime,
+): Promise<MultiCliHttpServer> {
+  validateHttpConfig(config);
+  const resolvedRuntime = runtime ?? await createServerRuntime(config, rootLogger);
+
+  const logger = rootLogger.child({ component: 'httpServer' });
+  const sessions = new Map<string, HttpSessionRecord>();
+
+  const app = createMcpExpressApp({ host: config.httpHost });
+  const originValidation = createOriginValidationMiddleware(logger, config.httpHost);
+  const authValidation = createAuthMiddleware(logger, config.httpAuthToken!);
+
+  const touchSession = (record: HttpSessionRecord) => {
+    record.lastActivityAt = Date.now();
+    if (record.idleTimer) {
+      clearTimeout(record.idleTimer);
+    }
+
+    record.idleTimer = setTimeout(() => {
+      void cleanupSession(record.sessionId, 'session idle timeout');
+    }, config.httpSessionIdleMs);
+    record.idleTimer.unref();
+  };
+
+  const cleanupSession = async (sessionId: string, reason: string) => {
+    const record = sessions.get(sessionId);
+    if (!record || record.closing) {
+      return;
+    }
+
+    record.closing = true;
+    if (record.idleTimer) {
+      clearTimeout(record.idleTimer);
+      record.idleTimer = undefined;
+    }
+
+    sessions.delete(sessionId);
+    record.logger.info('http_session_closing', {
+      reason,
+      lastActivityAt: new Date(record.lastActivityAt).toISOString(),
+    });
+
+    try {
+      await record.transport.close();
+    } catch (error) {
+      record.logger.error('http_session_transport_close_failed', { error, reason });
+    }
+
+    try {
+      await record.app.close(reason);
+    } catch (error) {
+      record.logger.error('http_session_app_close_failed', { error, reason });
+    }
+  };
+
+  app.get('/health', (_req: any, res: any) => {
+    res.json({
+      ok: true,
+      transport: 'http',
+      sessions: sessions.size,
+      path: config.httpPath,
+      host: config.httpHost,
+      port: config.httpPort,
+    });
+  });
+
+  app.use(config.httpPath, originValidation, authValidation);
+
+  app.post(config.httpPath, async (req: any, res: any) => {
+    const requestLogger = logger.child({
+      component: 'httpRequest',
+      method: 'POST',
+      path: req.path,
+      sessionId: req.headers['mcp-session-id'],
+    });
+
+    try {
+      const rawSessionId = req.headers['mcp-session-id'];
+      const sessionId = Array.isArray(rawSessionId) ? rawSessionId[0] : rawSessionId;
+
+      if (sessionId) {
+        const existing = sessions.get(sessionId);
+        if (!existing) {
+          requestLogger.error('http_session_missing', { sessionId });
+          res.status(404).json({
+            jsonrpc: '2.0',
+            error: {
+              code: -32000,
+              message: 'Unknown session',
+            },
+            id: null,
+          });
+          return;
+        }
+
+        touchSession(existing);
+        await existing.transport.handleRequest(req, res, req.body);
+        return;
+      }
+
+      if (!isInitializeRequest(req.body)) {
+        requestLogger.error('http_initialize_required');
+        res.status(400).json({
+          jsonrpc: '2.0',
+          error: {
+            code: -32000,
+            message: 'A new HTTP session must begin with initialize.',
+          },
+          id: null,
+        });
+        return;
+      }
+
+      const sessionContext: MultiCliSessionContext = {
+        transport: 'http',
+        resolveWorkingDirectory: async (server, sessionResolveLogger) => resolveWorkingDirectoryFromRoots(
+          server,
+          sessionResolveLogger,
+        ),
+      };
+      const sessionLogger = logger.child({
+        component: 'httpSession',
+      });
+      const sessionApp = await createServerApp(config, rootLogger, {
+        runtime: resolvedRuntime,
+        sessionContext,
+        onClientInitialized: async (server, _clientInfo, currentSessionContext) => {
+          const resolved = await resolveWorkingDirectoryFromRoots(
+            server,
+            sessionLogger.child({ component: 'roots' }),
+          );
+          currentSessionContext.cwd = resolved.cwd ?? currentSessionContext.cwd;
+          currentSessionContext.rootUri = resolved.rootUri;
+          currentSessionContext.projectRoots = resolved.projectRoots;
+        },
+      });
+
+      let sessionRecord: HttpSessionRecord | undefined;
+      const transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: () => randomUUID(),
+        onsessioninitialized: (newSessionId) => {
+          sessionRecord = {
+            sessionId: newSessionId,
+            app: sessionApp,
+            transport,
+            logger: sessionLogger.child({ sessionId: newSessionId }),
+            sessionContext,
+            lastActivityAt: Date.now(),
+            closing: false,
+          };
+
+          sessions.set(newSessionId, sessionRecord);
+          touchSession(sessionRecord);
+          sessionRecord.logger.info('http_session_initialized', {
+            cwd: sessionContext.cwd,
+            rootUri: sessionContext.rootUri,
+            projectRoots: sessionContext.projectRoots,
+          });
+        },
+        onsessionclosed: async (closedSessionId) => {
+          await cleanupSession(closedSessionId, 'client requested session close');
+        },
+        retryInterval: 1000,
+      });
+
+      await sessionApp.connect(transport);
+      await transport.handleRequest(req, res, req.body);
+
+      if (sessionRecord) {
+        touchSession(sessionRecord);
+      }
+    } catch (error) {
+      requestLogger.error('http_post_failed', { error });
+      if (!res.headersSent) {
+        res.status(500).json({
+          jsonrpc: '2.0',
+          error: {
+            code: -32603,
+            message: 'Internal server error',
+          },
+          id: null,
+        });
+      }
+    }
+  });
+
+  app.get(config.httpPath, async (req: any, res: any) => {
+    const rawSessionId = req.headers['mcp-session-id'];
+    const sessionId = Array.isArray(rawSessionId) ? rawSessionId[0] : rawSessionId;
+    if (!sessionId) {
+      res.status(400).send('Missing session ID');
+      return;
+    }
+
+    const record = sessions.get(sessionId);
+    if (!record) {
+      res.status(404).send('Unknown session');
+      return;
+    }
+
+    touchSession(record);
+    await record.transport.handleRequest(req, res);
+  });
+
+  app.delete(config.httpPath, async (req: any, res: any) => {
+    const rawSessionId = req.headers['mcp-session-id'];
+    const sessionId = Array.isArray(rawSessionId) ? rawSessionId[0] : rawSessionId;
+    if (!sessionId) {
+      res.status(400).send('Missing session ID');
+      return;
+    }
+
+    const record = sessions.get(sessionId);
+    if (!record) {
+      res.status(404).send('Unknown session');
+      return;
+    }
+
+    touchSession(record);
+    await record.transport.handleRequest(req, res);
+  });
+
+  const listener = await new Promise<HttpServer>((resolve, reject) => {
+    const server = app.listen(config.httpPort, config.httpHost, () => resolve(server));
+    server.once('error', reject);
+  });
+
+  logger.info('http_server_started', {
+    host: config.httpHost,
+    port: config.httpPort,
+    path: config.httpPath,
+  });
+
+  return {
+    config,
+    runtime: resolvedRuntime,
+    url: `http://${config.httpHost}:${config.httpPort}${config.httpPath}`,
+    healthUrl: `http://${config.httpHost}:${config.httpPort}/health`,
+    async close(reason = 'HTTP server shutting down') {
+      logger.info('http_server_closing', {
+        reason,
+        sessionCount: sessions.size,
+      });
+
+      await Promise.all(
+        [...sessions.keys()].map((sessionId) => cleanupSession(sessionId, reason)),
+      );
+
+      await new Promise<void>((resolve, reject) => {
+        listener.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      });
+
+      logger.info('http_server_closed', { reason });
+    },
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,25 +2,117 @@
 import 'dotenv/config';
 
 import { loadConfig } from './config.js';
+import { startHttpServer } from './httpServer.js';
 import { createLogger } from './logger.js';
-import { startServer } from './serverApp.js';
+import { startServer as startStdioServer } from './serverApp.js';
+import { handleServiceCommand } from './service/manager.js';
 
-const config = loadConfig();
-const logger = createLogger(config.logLevel);
+interface ClosableRuntime {
+  close(reason?: string): Promise<void>;
+}
+
+function parseCommand(argv: string[]): {
+  command: 'serve-stdio' | 'serve-http' | 'service';
+  args: string[];
+} {
+  const [firstArg, ...rest] = argv;
+
+  if (firstArg === 'serve-http') {
+    return { command: 'serve-http', args: rest };
+  }
+
+  if (firstArg === 'serve-stdio') {
+    return { command: 'serve-stdio', args: rest };
+  }
+
+  if (firstArg === 'service') {
+    return { command: 'service', args: rest };
+  }
+
+  return {
+    command: loadConfig().transport === 'http' ? 'serve-http' : 'serve-stdio',
+    args: argv,
+  };
+}
 
 async function main() {
-  const app = await startServer(config);
+  const parsed = parseCommand(process.argv.slice(2));
+  const config = loadConfig();
+  const rootLogger = createLogger({
+    filePath: config.logPath,
+    fileLevel: config.logLevel,
+    stderrLevel: config.stderrLogLevel,
+    bindings: { component: 'multicli' },
+  });
+  const logger = rootLogger.child({ component: 'index' });
 
-  const shutdown = (signalName: string) => {
-    logger.info('Received shutdown signal', { signalName });
-    void app.close(`Received ${signalName}`);
+  logger.info('process_bootstrap', {
+    config,
+    argv: process.argv,
+    parsedCommand: parsed.command,
+    cwd: process.cwd(),
+    nodeVersion: process.version,
+    platform: process.platform,
+  });
+
+  if (parsed.command === 'service') {
+    await handleServiceCommand(parsed.args, config, rootLogger);
+    return;
+  }
+
+  const runtime: ClosableRuntime = parsed.command === 'serve-http'
+    ? await startHttpServer({ ...config, transport: 'http' }, rootLogger)
+    : await startStdioServer({ ...config, transport: 'stdio' }, rootLogger);
+
+  const shutdown = async (signalName: string) => {
+    logger.info('process_signal_received', { signalName });
+    await runtime.close(`Received ${signalName}`);
   };
 
-  process.once('SIGINT', () => shutdown('SIGINT'));
-  process.once('SIGTERM', () => shutdown('SIGTERM'));
+  const handleFatalError = (event: string, error: unknown) => {
+    logger.error(event, { error });
+    process.exitCode = 1;
+    void runtime.close(event);
+    setTimeout(() => {
+      process.exit(1);
+    }, parsed.command === 'serve-http' ? 250 : 25).unref();
+  };
+
+  process.once('SIGINT', () => {
+    void shutdown('SIGINT');
+  });
+  process.once('SIGTERM', () => {
+    void shutdown('SIGTERM');
+  });
+  process.once('beforeExit', (code) => {
+    logger.info('process_before_exit', { code });
+  });
+  process.once('exit', (code) => {
+    logger.info('process_exit', { code });
+  });
+  process.on('warning', (warning) => {
+    logger.error('process_warning', { warning });
+  });
+  process.on('uncaughtExceptionMonitor', (error, origin) => {
+    logger.error('process_uncaught_exception_monitor', { error, origin });
+  });
+  process.on('uncaughtException', (error, origin) => {
+    handleFatalError('process_uncaught_exception', { error, origin });
+  });
+  process.on('unhandledRejection', (reason, promise) => {
+    handleFatalError('process_unhandled_rejection', { reason, promise });
+  });
 }
 
 main().catch((error) => {
-  logger.error('Server startup failed', { error });
+  const config = loadConfig();
+  const rootLogger = createLogger({
+    filePath: config.logPath,
+    fileLevel: config.logLevel,
+    stderrLevel: config.stderrLogLevel,
+    bindings: { component: 'multicli' },
+  });
+  const logger = rootLogger.child({ component: 'index' });
+  logger.error('server_startup_failed', { error });
   process.exit(1);
 });

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,4 +1,8 @@
-import { MultiCliLogLevel } from './config.js';
+import { randomUUID } from 'node:crypto';
+import { appendFileSync, existsSync, mkdirSync, renameSync, statSync } from 'node:fs';
+import path from 'node:path';
+
+import { MultiCliLogLevel, MultiCliStderrLogLevel } from './config.js';
 
 const LEVEL_PRIORITY: Record<MultiCliLogLevel, number> = {
   error: 0,
@@ -6,62 +10,214 @@ const LEVEL_PRIORITY: Record<MultiCliLogLevel, number> = {
   debug: 2,
 };
 
-function serializeValue(value: unknown): unknown {
+const MAX_LOG_FILE_SIZE_BYTES = 10 * 1024 * 1024;
+const MAX_LOG_BACKUPS = 5;
+
+function shouldWrite(
+  currentLevel: MultiCliLogLevel,
+  minimumLevel: MultiCliLogLevel | MultiCliStderrLogLevel,
+): boolean {
+  if (minimumLevel === 'silent') {
+    return false;
+  }
+
+  return LEVEL_PRIORITY[currentLevel] <= LEVEL_PRIORITY[minimumLevel];
+}
+
+function serializeValue(
+  value: unknown,
+  seen = new WeakSet<object>(),
+): unknown {
   if (value instanceof Error) {
     return {
       name: value.name,
       message: value.message,
       stack: value.stack,
+      cause: serializeValue(value.cause, seen),
+    };
+  }
+
+  if (typeof value === 'bigint') {
+    return value.toString();
+  }
+
+  if (typeof value === 'function') {
+    return `[Function ${value.name || 'anonymous'}]`;
+  }
+
+  if (typeof value === 'symbol') {
+    return value.toString();
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  if (Buffer.isBuffer(value)) {
+    return {
+      type: 'Buffer',
+      length: value.length,
+      utf8: value.toString('utf8'),
     };
   }
 
   if (Array.isArray(value)) {
-    return value.map(serializeValue);
+    return value.map((entry) => serializeValue(entry, seen));
   }
 
   if (value && typeof value === 'object') {
-    return Object.fromEntries(
-      Object.entries(value).map(([key, entry]) => [key, serializeValue(entry)]),
+    if (seen.has(value)) {
+      return '[Circular]';
+    }
+
+    seen.add(value);
+    const serialized = Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [
+        key,
+        shouldRedactKey(key) ? '[Redacted]' : serializeValue(entry, seen),
+      ]),
     );
+    seen.delete(value);
+    return serialized;
   }
 
   return value;
 }
 
-function formatMeta(meta: Record<string, unknown> | undefined): string {
-  if (!meta || Object.keys(meta).length === 0) {
-    return '';
-  }
-
-  return ` ${JSON.stringify(serializeValue(meta))}`;
+function shouldRedactKey(key: string): boolean {
+  const normalized = key.toLowerCase();
+  return normalized.includes('authorization')
+    || normalized.includes('token')
+    || normalized.includes('cookie')
+    || normalized.includes('api-key')
+    || normalized.includes('apikey');
 }
 
-export interface Logger {
-  error(message: string, meta?: Record<string, unknown>): void;
-  info(message: string, meta?: Record<string, unknown>): void;
-  debug(message: string, meta?: Record<string, unknown>): void;
-}
-
-export function createLogger(level: MultiCliLogLevel): Logger {
-  const minimumPriority = LEVEL_PRIORITY[level];
-
-  const write = (
-    currentLevel: MultiCliLogLevel,
-    message: string,
-    meta?: Record<string, unknown>,
-  ) => {
-    if (LEVEL_PRIORITY[currentLevel] > minimumPriority) {
+function rotateLogsIfNeeded(logPath: string) {
+  try {
+    if (!existsSync(logPath)) {
       return;
     }
 
-    process.stderr.write(
-      `[Multi-CLI] [${currentLevel}] ${message}${formatMeta(meta)}\n`,
-    );
-  };
+    const { size } = statSync(logPath);
+    if (size < MAX_LOG_FILE_SIZE_BYTES) {
+      return;
+    }
 
-  return {
-    error: (message, meta) => write('error', message, meta),
-    info: (message, meta) => write('info', message, meta),
-    debug: (message, meta) => write('debug', message, meta),
-  };
+    for (let index = MAX_LOG_BACKUPS - 1; index >= 1; index -= 1) {
+      const currentPath = `${logPath}.${index}`;
+      const nextPath = `${logPath}.${index + 1}`;
+      if (existsSync(currentPath)) {
+        renameSync(currentPath, nextPath);
+      }
+    }
+
+    renameSync(logPath, `${logPath}.1`);
+  } catch {
+    // Rotation is best-effort only.
+  }
+}
+
+export interface Logger {
+  readonly logPath: string;
+  readonly sessionId: string;
+  child(bindings: Record<string, unknown>): Logger;
+  error(event: string, meta?: Record<string, unknown>): void;
+  info(event: string, meta?: Record<string, unknown>): void;
+  debug(event: string, meta?: Record<string, unknown>): void;
+}
+
+interface LoggerOptions {
+  filePath: string;
+  fileLevel: MultiCliLogLevel;
+  stderrLevel?: MultiCliStderrLogLevel;
+  sessionId?: string;
+  bindings?: Record<string, unknown>;
+}
+
+class StructuredLogger implements Logger {
+  readonly logPath: string;
+  readonly sessionId: string;
+
+  constructor(
+    private readonly options: LoggerOptions,
+  ) {
+    this.logPath = options.filePath;
+    this.sessionId = options.sessionId ?? randomUUID();
+    mkdirSync(path.dirname(this.logPath), { recursive: true });
+  }
+
+  child(bindings: Record<string, unknown>): Logger {
+    return new StructuredLogger({
+      ...this.options,
+      sessionId: this.sessionId,
+      bindings: {
+        ...(this.options.bindings ?? {}),
+        ...bindings,
+      },
+    });
+  }
+
+  error(event: string, meta?: Record<string, unknown>): void {
+    this.write('error', event, meta);
+  }
+
+  info(event: string, meta?: Record<string, unknown>): void {
+    this.write('info', event, meta);
+  }
+
+  debug(event: string, meta?: Record<string, unknown>): void {
+    this.write('debug', event, meta);
+  }
+
+  private write(
+    level: MultiCliLogLevel,
+    event: string,
+    meta?: Record<string, unknown>,
+  ): void {
+    const entry = {
+      timestamp: new Date().toISOString(),
+      level,
+      event,
+      sessionId: this.sessionId,
+      pid: process.pid,
+      ...(serializeValue(this.options.bindings ?? {}) as Record<string, unknown>),
+      ...(meta ? { meta: serializeValue(meta) } : {}),
+    };
+
+    const line = `${JSON.stringify(entry)}\n`;
+
+    try {
+      if (shouldWrite(level, this.options.fileLevel)) {
+        rotateLogsIfNeeded(this.logPath);
+        appendFileSync(this.logPath, line, 'utf8');
+      }
+    } catch (error) {
+      const fallback = JSON.stringify({
+        timestamp: new Date().toISOString(),
+        level: 'error',
+        event: 'logger_file_write_failed',
+        sessionId: this.sessionId,
+        pid: process.pid,
+        component: 'logger',
+        meta: serializeValue({
+          targetPath: this.logPath,
+          originalLevel: level,
+          originalEvent: event,
+          error,
+        }),
+      });
+      process.stderr.write(`${fallback}\n`);
+      return;
+    }
+
+    const stderrLevel = this.options.stderrLevel ?? 'error';
+    if (shouldWrite(level, stderrLevel)) {
+      process.stderr.write(line);
+    }
+  }
+}
+
+export function createLogger(options: LoggerOptions): Logger {
+  return new StructuredLogger(options);
 }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import { appendFileSync, existsSync, mkdirSync, renameSync, statSync } from 'node:fs';
+import { appendFileSync, existsSync, mkdirSync, renameSync, rmSync, statSync } from 'node:fs';
 import path from 'node:path';
 
 import { MultiCliLogLevel, MultiCliStderrLogLevel } from './config.js';
@@ -29,12 +29,19 @@ function serializeValue(
   seen = new WeakSet<object>(),
 ): unknown {
   if (value instanceof Error) {
-    return {
+    if (seen.has(value)) {
+      return '[Circular]';
+    }
+
+    seen.add(value);
+    const serialized = {
       name: value.name,
       message: value.message,
       stack: value.stack,
       cause: serializeValue(value.cause, seen),
     };
+    seen.delete(value);
+    return serialized;
   }
 
   if (typeof value === 'bigint') {
@@ -104,6 +111,7 @@ function rotateLogsIfNeeded(logPath: string) {
       return;
     }
 
+    rmSync(`${logPath}.${MAX_LOG_BACKUPS}`, { force: true });
     for (let index = MAX_LOG_BACKUPS - 1; index >= 1; index -= 1) {
       const currentPath = `${logPath}.${index}`;
       const nextPath = `${logPath}.${index + 1}`;

--- a/src/serverApp.ts
+++ b/src/serverApp.ts
@@ -1,3 +1,5 @@
+import { fileURLToPath } from 'node:url';
+
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
@@ -20,6 +22,8 @@ import {
   type GetPromptResult,
   type CallToolResult,
   type CreateTaskResult,
+  type Implementation,
+  type ListRootsResult,
 } from "@modelcontextprotocol/sdk/types.js";
 import { PROTOCOL, ToolArguments } from "./constants.js";
 import { MultiCliConfig, loadConfig } from "./config.js";
@@ -40,12 +44,45 @@ import {
 import { importantReadNowTool } from './tools/important-read-now.tool.js';
 import { filterToolsForClient, isToolBlockedForClient } from './clientFilter.js';
 import { CommandExecutionError } from "./utils/commandExecutor.js";
+import type { CliAvailability } from "./utils/cliDetector.js";
 
 type HandlerExtra = RequestHandlerExtra<ServerRequest, ServerNotification>;
 type ProgressToken = string | number | undefined;
 type TaskExecution = {
   controller: AbortController;
 };
+
+export interface MultiCliRuntime {
+  availability: CliAvailability;
+  initializedAt: string;
+}
+
+export interface MultiCliSessionContext {
+  cwd?: string;
+  rootUri?: string;
+  projectRoots?: ListRootsResult['roots'];
+  env?: NodeJS.ProcessEnv;
+  transport?: 'stdio' | 'http';
+  clientName?: string;
+  resolveWorkingDirectory?: (
+    server: Server,
+    logger: Logger,
+  ) => Promise<{
+    cwd?: string;
+    rootUri?: string;
+    projectRoots?: ListRootsResult['roots'];
+  }>;
+}
+
+export interface CreateServerAppOptions {
+  runtime?: MultiCliRuntime;
+  sessionContext?: MultiCliSessionContext;
+  onClientInitialized?: (
+    server: Server,
+    clientInfo: Implementation | undefined,
+    sessionContext: MultiCliSessionContext,
+  ) => Promise<void> | void;
+}
 
 function buildToolResult(text: string, isError: boolean): CallToolResult {
   return {
@@ -110,10 +147,71 @@ function getErrorMeta(error: unknown): Record<string, unknown> | undefined {
   }
 
   if (error instanceof Error) {
-    return { message: error.message };
+    return { error };
   }
 
   return undefined;
+}
+
+export async function createServerRuntime(
+  config: MultiCliConfig = loadConfig(),
+  rootLogger: Logger = createLogger({
+    filePath: config.logPath,
+    fileLevel: config.logLevel,
+    stderrLevel: config.stderrLogLevel,
+    bindings: { component: 'multicli' },
+  }),
+): Promise<MultiCliRuntime> {
+  const logger = rootLogger.child({ component: 'serverRuntime' });
+  logger.info('server_runtime_initializing', { config });
+
+  const availability = await initTools({
+    cliDetectTimeoutMs: config.cliDetectTimeoutMs,
+    logger: rootLogger.child({ component: 'cliDetector' }),
+  });
+
+  const runtime: MultiCliRuntime = {
+    availability,
+    initializedAt: new Date().toISOString(),
+  };
+
+  logger.info('server_runtime_initialized', { runtime });
+  return runtime;
+}
+
+export async function resolveWorkingDirectoryFromRoots(
+  server: Server,
+  logger: Logger,
+): Promise<{
+  cwd?: string;
+  rootUri?: string;
+  projectRoots?: ListRootsResult['roots'];
+}> {
+  try {
+    const rootsResult = await server.listRoots();
+    const projectRoots = rootsResult.roots;
+    const rootUri = rootsResult.roots.at(0)?.uri;
+    if (!rootUri) {
+      logger.info('session_roots_empty');
+      return { projectRoots };
+    }
+
+    if (!rootUri.startsWith('file://')) {
+      logger.error('session_root_uri_unsupported', { rootUri });
+      return { rootUri, projectRoots };
+    }
+
+    const cwd = fileURLToPath(rootUri);
+    logger.info('session_working_directory_resolved', {
+      cwd,
+      rootUri,
+      projectRoots,
+    });
+    return { cwd, rootUri, projectRoots };
+  } catch (error) {
+    logger.error('session_working_directory_resolution_failed', { error });
+    return {};
+  }
 }
 
 function createProgressReporter(
@@ -124,12 +222,29 @@ function createProgressReporter(
   operationName: string,
 ) {
   let completed = false;
+  let stopping = false;
   let timeout: NodeJS.Timeout | undefined;
   let progress = 0;
   let lastOutputAt = Date.now();
   let lastNotificationAt = 0;
   let latestPreview: string | undefined;
-  let flushInFlight = false;
+  let queuedWork: Promise<void> = Promise.resolve();
+
+  const queueProgressWork = (work: () => Promise<void>) => {
+    queuedWork = queuedWork.then(work, work);
+    return queuedWork;
+  };
+
+  const waitForQueuedWork = async () => {
+    try {
+      await queuedWork;
+    } catch (error) {
+      logger.debug('progress_work_failed', {
+        operationName,
+        error,
+      });
+    }
+  };
 
   const sendProgressNotification = async (
     currentProgress: number,
@@ -156,15 +271,15 @@ function createProgressReporter(
       });
       lastNotificationAt = Date.now();
     } catch (error) {
-      logger.debug('Progress notification failed', {
+      logger.debug('progress_notification_failed', {
         operationName,
         error,
       });
     }
   };
 
-  const flushPreview = async (force = false) => {
-    if (completed || !latestPreview || flushInFlight) {
+  const flushPreview = async (force = false, allowWhileStopping = false) => {
+    if (completed || (!allowWhileStopping && stopping) || !latestPreview) {
       return;
     }
 
@@ -172,47 +287,45 @@ function createProgressReporter(
       return;
     }
 
-    flushInFlight = true;
     const preview = latestPreview;
     latestPreview = undefined;
     progress += 1;
     await sendProgressNotification(progress, preview);
-    flushInFlight = false;
-
-    if (latestPreview && !completed) {
-      void flushPreview();
-    }
   };
 
   const scheduleHeartbeat = () => {
-    timeout = setTimeout(async () => {
-      if (completed) {
-        return;
-      }
+    timeout = setTimeout(() => {
+      void queueProgressWork(async () => {
+        if (completed || stopping) {
+          return;
+        }
 
-      if (latestPreview) {
-        await flushPreview(true);
-      } else if (Date.now() - lastOutputAt >= config.progressIdleHeartbeatMs) {
-        progress += 1;
-        await sendProgressNotification(
-          progress,
-          `Still running ${operationName}...`,
-        );
-      }
-
-      if (!completed) {
-        scheduleHeartbeat();
-      }
+        if (latestPreview) {
+          await flushPreview(true);
+        } else if (Date.now() - lastOutputAt >= config.progressIdleHeartbeatMs) {
+          progress += 1;
+          await sendProgressNotification(
+            progress,
+            `Still running ${operationName}...`,
+          );
+        }
+      }).finally(() => {
+        if (!completed && !stopping) {
+          scheduleHeartbeat();
+        }
+      });
     }, config.progressIdleHeartbeatMs);
   };
 
   return {
     start: async () => {
-      await sendProgressNotification(0, `Starting ${operationName}`);
+      await queueProgressWork(async () => {
+        await sendProgressNotification(0, `Starting ${operationName}`);
+      });
       scheduleHeartbeat();
     },
     onOutput: (chunk: string) => {
-      if (completed) {
+      if (completed || stopping) {
         return;
       }
 
@@ -224,26 +337,36 @@ function createProgressReporter(
 
       latestPreview = preview;
       if (Date.now() - lastNotificationAt >= config.progressThrottleMs) {
-        void flushPreview(true);
+        void queueProgressWork(async () => {
+          await flushPreview(true);
+        });
       }
     },
     stop: async (status: 'success' | 'failed' | 'cancelled') => {
-      if (latestPreview) {
-        await flushPreview(true);
+      if (stopping) {
+        await waitForQueuedWork();
+        return;
       }
 
-      completed = true;
+      stopping = true;
       if (timeout) {
         clearTimeout(timeout);
       }
 
-      if (status === 'success') {
-        await sendProgressNotification(100, `Completed ${operationName}`, 100);
-      } else if (status === 'cancelled') {
-        await sendProgressNotification(100, `Cancelled ${operationName}`, 100);
-      } else {
-        await sendProgressNotification(100, `Failed ${operationName}`, 100);
-      }
+      await queueProgressWork(async () => {
+        await flushPreview(true, true);
+        completed = true;
+
+        if (status === 'success') {
+          await sendProgressNotification(100, `Completed ${operationName}`, 100);
+        } else if (status === 'cancelled') {
+          await sendProgressNotification(100, `Cancelled ${operationName}`, 100);
+        } else {
+          await sendProgressNotification(100, `Failed ${operationName}`, 100);
+        }
+      });
+
+      await waitForQueuedWork();
     },
   };
 }
@@ -257,10 +380,24 @@ export interface MultiCliServerApp {
 
 export async function createServerApp(
   config: MultiCliConfig = loadConfig(),
+  rootLogger: Logger = createLogger({
+    filePath: config.logPath,
+    fileLevel: config.logLevel,
+    stderrLevel: config.stderrLogLevel,
+    bindings: { component: 'multicli' },
+  }),
+  options: CreateServerAppOptions = {},
 ): Promise<MultiCliServerApp> {
-  await initTools({ cliDetectTimeoutMs: config.cliDetectTimeoutMs });
+  const logger = rootLogger.child({ component: 'serverApp' });
+  const sessionContext = options.sessionContext ?? { transport: 'stdio', cwd: process.cwd() };
+  const runtime = options.runtime ?? await createServerRuntime(config, rootLogger);
 
-  const logger = createLogger(config.logLevel);
+  logger.info('server_app_initializing', {
+    config,
+    runtime,
+    sessionContext,
+  });
+
   const taskStore = new ManagedTaskStore();
   const activeTasks = new Map<string, TaskExecution>();
 
@@ -291,9 +428,52 @@ export async function createServerApp(
   let connectedClientName: string | undefined;
   let closed = false;
 
+  const resolveSessionExecutionContext = async (requestLogger: Logger): Promise<{
+    cwd?: string;
+    projectRoots?: ListRootsResult['roots'];
+  }> => {
+    if (sessionContext.cwd || sessionContext.projectRoots) {
+      return {
+        cwd: sessionContext.cwd,
+        projectRoots: sessionContext.projectRoots,
+      };
+    }
+
+    if (!sessionContext.resolveWorkingDirectory) {
+      return {
+        cwd: sessionContext.cwd,
+        projectRoots: sessionContext.projectRoots,
+      };
+    }
+
+    const result = await sessionContext.resolveWorkingDirectory(
+      server,
+      requestLogger.child({ component: 'workingDirectory' }),
+    );
+
+    if (result.cwd) {
+      sessionContext.cwd = result.cwd;
+    }
+    if (result.rootUri) {
+      sessionContext.rootUri = result.rootUri;
+    }
+    if (result.projectRoots) {
+      sessionContext.projectRoots = result.projectRoots;
+    }
+
+    return {
+      cwd: sessionContext.cwd,
+      projectRoots: sessionContext.projectRoots,
+    };
+  };
+
   const abortActiveTasks = (reason: string) => {
+    logger.info('active_task_abort_started', {
+      reason,
+      activeTaskCount: activeTasks.size,
+    });
     for (const [taskId, taskExecution] of activeTasks.entries()) {
-      logger.info('Aborting active task', { taskId, reason });
+      logger.info('active_task_aborting', { taskId, reason });
       taskExecution.controller.abort(new Error(reason));
     }
   };
@@ -301,17 +481,23 @@ export async function createServerApp(
   server.oninitialized = () => {
     const clientInfo = server.getClientVersion();
     connectedClientName = clientInfo?.name;
-    logger.info('Client initialized', {
-      clientName: connectedClientName,
+    sessionContext.clientName = connectedClientName;
+    logger.info('client_initialized', {
+      client: clientInfo,
+      transport: sessionContext.transport,
     });
+    void options.onClientInitialized?.(server, clientInfo, sessionContext);
   };
 
   server.onerror = (error) => {
-    logger.error('Server error', { error });
+    logger.error('server_error', { error });
   };
 
   server.onclose = () => {
-    logger.info('Server transport closed');
+    logger.info('server_transport_closed', {
+      connectedClientName,
+      activeTaskCount: activeTasks.size,
+    });
   };
 
   const executeToolRequest = async (
@@ -321,13 +507,24 @@ export async function createServerApp(
     extra: HandlerExtra,
     taskId?: string,
   ): Promise<string> => {
+    const requestLogger = logger.child({
+      component: 'toolExecution',
+      toolName,
+      requestId: extra.requestId,
+      ...(taskId ? { taskId } : {}),
+    });
+    const { cwd, projectRoots } = await resolveSessionExecutionContext(requestLogger);
     const executionContext: ToolExecutionContext = {
       signal: extra.signal,
       onProgress: (newOutput) => progressReporter.onOutput(newOutput),
       timeoutMs: getTimeoutForTool(toolName, config),
       killGraceMs: config.killGraceMs,
+      cwd,
+      projectRoots,
+      env: sessionContext.env,
       requestId: extra.requestId,
       taskId,
+      logger: requestLogger,
     };
 
     const tool = getTool(toolName);
@@ -340,6 +537,10 @@ export async function createServerApp(
 
   server.setRequestHandler(ListToolsRequestSchema, async (_request: ListToolsRequest): Promise<{ tools: Tool[] }> => {
     const visible = filterToolsForClient(toolRegistry, connectedClientName);
+    logger.debug('list_tools_requested', {
+      connectedClientName,
+      visibleToolNames: visible.map((tool) => tool.name),
+    });
     if (visible.length === 0) {
       return { tools: getToolDefinitions([importantReadNowTool]) as unknown as Tool[] };
     }
@@ -369,13 +570,19 @@ export async function createServerApp(
     const args: ToolArguments = (request.params.arguments as ToolArguments) || {};
     const validatedArgs = validateToolArguments(toolName, args);
     const progressToken = (request.params as { _meta?: { progressToken?: ProgressToken } })._meta?.progressToken;
-    const progressReporter = createProgressReporter(server, logger, config, progressToken, toolName);
-    const taskParams = (request.params as { task?: { ttl?: number | null; pollInterval?: number } }).task;
-
-    logger.info('Tool request started', {
+    const requestLogger = logger.child({
+      component: 'toolRequest',
       requestId: extra.requestId,
       toolName,
+    });
+    const progressReporter = createProgressReporter(server, requestLogger, config, progressToken, toolName);
+    const taskParams = (request.params as { task?: { ttl?: number | null; pollInterval?: number } }).task;
+
+    requestLogger.info('tool_request_started', {
       task: !!taskParams,
+      taskParams,
+      progressToken,
+      arguments: validatedArgs,
     });
 
     if (taskParams) {
@@ -401,22 +608,35 @@ export async function createServerApp(
       const controller = new AbortController();
       activeTasks.set(task.taskId, { controller });
       taskStore.registerCancelHandler(task.taskId, (reason) => {
-        logger.info('Task cancellation requested', {
+        requestLogger.info('task_cancellation_requested', {
           taskId: task.taskId,
-          toolName,
           reason,
         });
         controller.abort(new Error(reason ?? 'Task cancelled'));
       });
 
+      const taskLogger = requestLogger.child({
+        component: 'taskExecution',
+        taskId: task.taskId,
+      });
+      const { cwd, projectRoots } = await resolveSessionExecutionContext(taskLogger);
       const taskExecutionContext: ToolExecutionContext = {
         signal: controller.signal,
         onProgress: (newOutput) => progressReporter.onOutput(newOutput),
         timeoutMs: getTimeoutForTool(toolName, config),
         killGraceMs: config.killGraceMs,
+        cwd,
+        projectRoots,
+        env: sessionContext.env,
         requestId: extra.requestId,
         taskId: task.taskId,
+        logger: taskLogger,
       };
+
+      requestLogger.info('task_created', {
+        taskId: task.taskId,
+        taskParams,
+      });
 
       void (async () => {
         await progressReporter.start();
@@ -433,16 +653,15 @@ export async function createServerApp(
             buildToolResult(result, false),
           );
           await progressReporter.stop('success');
-          logger.info('Task completed', {
-            toolName,
+          taskLogger.info('task_completed', {
             taskId: task.taskId,
+            resultLength: result.length,
           });
         } catch (error) {
           const currentTask = await taskStore.getTask(task.taskId);
           if (currentTask?.status === 'cancelled' || controller.signal.aborted) {
             await progressReporter.stop('cancelled');
-            logger.info('Task cancelled', {
-              toolName,
+            taskLogger.info('task_cancelled', {
               taskId: task.taskId,
             });
           } else {
@@ -452,9 +671,7 @@ export async function createServerApp(
               buildErrorResult(toolName, error),
             );
             await progressReporter.stop('failed');
-            logger.error('Task failed', {
-              toolName,
-              taskId: task.taskId,
+            taskLogger.error('task_failed', {
               ...getErrorMeta(error),
             });
           }
@@ -463,8 +680,7 @@ export async function createServerApp(
           taskStore.clearCancelHandler(task.taskId);
         }
       })().catch((error) => {
-        logger.error('Unexpected task execution failure', {
-          toolName,
+        requestLogger.error('task_execution_unexpected_failure', {
           taskId: task.taskId,
           error,
         });
@@ -484,9 +700,8 @@ export async function createServerApp(
       );
 
       await progressReporter.stop('success');
-      logger.info('Tool request completed', {
-        requestId: extra.requestId,
-        toolName,
+      requestLogger.info('tool_request_completed', {
+        resultLength: result.length,
       });
 
       return buildToolResult(result, false);
@@ -496,9 +711,7 @@ export async function createServerApp(
         : 'failed';
       await progressReporter.stop(status);
 
-      logger.error('Tool request failed', {
-        requestId: extra.requestId,
-        toolName,
+      requestLogger.error('tool_request_failed', {
         ...getErrorMeta(error),
       });
 
@@ -508,6 +721,10 @@ export async function createServerApp(
 
   server.setRequestHandler(ListPromptsRequestSchema, async (_request: ListPromptsRequest): Promise<{ prompts: Prompt[] }> => {
     const visible = filterToolsForClient(toolRegistry, connectedClientName);
+    logger.debug('list_prompts_requested', {
+      connectedClientName,
+      visiblePromptNames: visible.filter((tool) => tool.prompt).map((tool) => tool.name),
+    });
     return { prompts: getPromptDefinitions(visible) as unknown as Prompt[] };
   });
 
@@ -525,6 +742,11 @@ export async function createServerApp(
       throw new Error(`Unknown prompt: ${promptName}`);
     }
 
+    logger.debug('get_prompt_requested', {
+      promptName,
+      arguments: args,
+    });
+
     return {
       messages: [{
         role: "user" as const,
@@ -540,38 +762,81 @@ export async function createServerApp(
     server,
     config,
     async connect(transport: Transport) {
+      logger.info('server_connect_started', {
+        transport: transport.constructor.name,
+      });
       await server.connect(transport);
+      logger.info('server_connect_completed', {
+        transport: transport.constructor.name,
+      });
     },
     async close(reason = 'Server shutting down') {
       if (closed) {
+        logger.debug('server_close_ignored', { reason });
         return;
       }
 
       closed = true;
+      logger.info('server_close_started', {
+        reason,
+        activeTaskCount: activeTasks.size,
+      });
       abortActiveTasks(reason);
       taskStore.cleanup();
       await server.close();
+      logger.info('server_close_completed', { reason });
     },
   };
 }
 
 export async function startServer(
   config: MultiCliConfig = loadConfig(),
+  rootLogger: Logger = createLogger({
+    filePath: config.logPath,
+    fileLevel: config.logLevel,
+    stderrLevel: config.stderrLogLevel,
+    bindings: { component: 'multicli' },
+  }),
 ): Promise<MultiCliServerApp> {
-  const logger = createLogger(config.logLevel);
-  const app = await createServerApp(config);
+  const logger = rootLogger.child({ component: 'startServer' });
+  logger.info('stdio_server_starting', { config });
+  const runtime = await createServerRuntime(config, rootLogger);
+  const app = await createServerApp(config, rootLogger, {
+    runtime,
+    sessionContext: {
+      transport: 'stdio',
+      cwd: process.cwd(),
+    },
+    onClientInitialized: async (server, _clientInfo, sessionContext) => {
+      const resolved = await resolveWorkingDirectoryFromRoots(
+        server,
+        rootLogger.child({ component: 'stdioSession' }),
+      );
+      sessionContext.cwd = resolved.cwd ?? sessionContext.cwd;
+      sessionContext.rootUri = resolved.rootUri;
+      sessionContext.projectRoots = resolved.projectRoots;
+    },
+  });
   const transport = new StdioServerTransport();
 
   process.stdin.once('end', () => {
-    logger.info('stdin ended; closing server');
+    logger.info('stdin_ended');
     void app.close('stdin ended');
   });
 
   process.stdin.once('close', () => {
-    logger.info('stdin closed; closing server');
+    logger.info('stdin_closed');
     void app.close('stdin closed');
   });
 
+  process.stdin.once('error', (error) => {
+    logger.error('stdin_error', { error });
+    void app.close('stdin error');
+  });
+
   await app.connect(transport);
+  logger.info('stdio_server_started', {
+    transport: transport.constructor.name,
+  });
   return app;
 }

--- a/src/service/bootstrap.ts
+++ b/src/service/bootstrap.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+export function loadServiceEnvironment(
+  envFilePath: string,
+  targetEnv: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
+  const raw = readFileSync(envFilePath, 'utf8');
+  const parsed = JSON.parse(raw) as Record<string, unknown>;
+
+  for (const [key, value] of Object.entries(parsed)) {
+    if (typeof value !== 'string') {
+      throw new Error(`Service environment value for ${key} must be a string.`);
+    }
+    targetEnv[key] = value;
+  }
+
+  return targetEnv;
+}
+
+export async function runServiceBootstrap(argv = process.argv.slice(2)): Promise<void> {
+  const [envFilePath, entrypointPath, ...entrypointArgs] = argv;
+
+  if (!envFilePath || !entrypointPath) {
+    throw new Error('Usage: bootstrap <env-file> <entrypoint> [args...]');
+  }
+
+  loadServiceEnvironment(envFilePath);
+  process.argv = [process.execPath, entrypointPath, ...entrypointArgs];
+  await import(pathToFileURL(entrypointPath).href);
+}
+
+const isMainModule = process.argv[1]
+  && path.resolve(fileURLToPath(import.meta.url)) === path.resolve(process.argv[1]);
+
+if (isMainModule) {
+  void runServiceBootstrap().catch((error) => {
+    process.stderr.write(`${String(error)}\n`);
+    process.exit(1);
+  });
+}

--- a/src/service/manager.ts
+++ b/src/service/manager.ts
@@ -1,9 +1,13 @@
 import {
+  closeSync,
   chmodSync,
   existsSync,
   mkdirSync,
+  openSync,
+  readSync,
   readFileSync,
   rmSync,
+  statSync,
   unlinkSync,
   writeFileSync,
 } from 'node:fs';
@@ -25,7 +29,6 @@ import {
   SERVICE_LABEL,
   SYSTEMD_UNIT_NAME,
   WINDOWS_TASK_NAME,
-  getServiceKind,
 } from './paths.js';
 import type { ServiceManifest } from './types.js';
 
@@ -52,7 +55,7 @@ function writeTextFile(filePath: string, contents: string, mode?: number) {
 }
 
 function loadManifest(config: MultiCliConfig): ServiceManifest {
-  const manifestPath = path.join(config.serviceRootDir, 'manifest.json');
+  const manifestPath = config.serviceManifestPath;
   if (!existsSync(manifestPath)) {
     throw new Error(`Multi-CLI service is not installed. Missing manifest at ${manifestPath}`);
   }
@@ -249,7 +252,7 @@ async function installService(
   logger: Logger,
   options: ServiceInstallOptions,
 ): Promise<ServiceManifest> {
-  const existingToken = options.preserveToken && existsSync(path.join(config.serviceRootDir, 'manifest.json'))
+  const existingToken = options.preserveToken && existsSync(config.serviceManifestPath)
     ? loadManifest(config).transport.token
     : undefined;
   const token = config.httpAuthToken ?? existingToken ?? generateServiceToken();
@@ -292,8 +295,32 @@ function tailFile(filePath: string, lineCount = 200): string {
     return `Log file not found: ${filePath}`;
   }
 
-  const contents = readFileSync(filePath, 'utf8');
-  return contents.split('\n').slice(-lineCount).join('\n');
+  const fileDescriptor = openSync(filePath, 'r');
+
+  try {
+    const { size } = statSync(filePath);
+    if (size === 0) {
+      return '';
+    }
+
+    const chunkSize = 4096;
+    let position = size;
+    let contents = '';
+    let newlineCount = 0;
+
+    while (position > 0 && newlineCount <= lineCount) {
+      const bytesToRead = Math.min(chunkSize, position);
+      position -= bytesToRead;
+      const chunkBuffer = Buffer.alloc(bytesToRead);
+      readSync(fileDescriptor, chunkBuffer, 0, bytesToRead, position);
+      contents = chunkBuffer.toString('utf8') + contents;
+      newlineCount = contents.split('\n').length - 1;
+    }
+
+    return contents.split('\n').slice(-lineCount).join('\n');
+  } finally {
+    closeSync(fileDescriptor);
+  }
 }
 
 export async function handleServiceCommand(
@@ -384,7 +411,7 @@ export async function handleServiceCommand(
       const manifest = loadManifest(config);
       const status = await getServiceStatus(manifest, serviceLogger);
       const claudeConfig = await inspectClaudeConfig(manifest, serviceLogger);
-      let health = 'unreachable';
+      let health: string;
       try {
         const response = await fetch(manifest.transport.healthUrl);
         health = response.ok ? 'ok' : `http ${response.status}`;

--- a/src/service/manager.ts
+++ b/src/service/manager.ts
@@ -1,0 +1,424 @@
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import path from 'node:path';
+
+import type { MultiCliConfig } from '../config.js';
+import { detectAvailableClis } from '../utils/cliDetector.js';
+import { executeCommand } from '../utils/commandExecutor.js';
+import type { Logger } from '../logger.js';
+import { createServiceManifest, buildServiceEnvFileContents, generateServiceToken } from './runtime.js';
+import {
+  renderLaunchAgent,
+  renderPosixLauncher,
+  renderSystemdUnit,
+  renderWindowsLauncher,
+  renderWindowsTaskXml,
+} from './renderers.js';
+import {
+  SERVICE_LABEL,
+  SYSTEMD_UNIT_NAME,
+  WINDOWS_TASK_NAME,
+  getServiceKind,
+} from './paths.js';
+import type { ServiceManifest } from './types.js';
+
+interface ServiceInstallOptions {
+  configureClaude?: boolean;
+  preserveToken?: boolean;
+}
+
+interface ClaudeConfigInspection {
+  present: boolean;
+  matchesManagedService: boolean;
+}
+
+function ensureParentDir(filePath: string) {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+}
+
+function writeTextFile(filePath: string, contents: string, mode?: number) {
+  ensureParentDir(filePath);
+  writeFileSync(filePath, contents, { encoding: 'utf8', mode: mode ?? 0o666 });
+  if (mode !== undefined && process.platform !== 'win32') {
+    chmodSync(filePath, mode);
+  }
+}
+
+function loadManifest(config: MultiCliConfig): ServiceManifest {
+  const manifestPath = path.join(config.serviceRootDir, 'manifest.json');
+  if (!existsSync(manifestPath)) {
+    throw new Error(`Multi-CLI service is not installed. Missing manifest at ${manifestPath}`);
+  }
+
+  return JSON.parse(readFileSync(manifestPath, 'utf8')) as ServiceManifest;
+}
+
+async function runBestEffort(command: string, args: string[], logger: Logger) {
+  try {
+    await executeCommand(command, args, { logger });
+  } catch (error) {
+    logger.debug('service_command_ignored_failure', {
+      command,
+      args,
+      error,
+    });
+  }
+}
+
+async function waitForHealth(manifest: ServiceManifest, logger: Logger) {
+  const deadline = Date.now() + 15_000;
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(manifest.transport.healthUrl);
+      if (response.ok) {
+        logger.info('service_health_check_passed', {
+          healthUrl: manifest.transport.healthUrl,
+        });
+        return;
+      }
+    } catch (error) {
+      logger.debug('service_health_check_retrying', { error });
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+
+  throw new Error(`Timed out waiting for service health at ${manifest.transport.healthUrl}`);
+}
+
+async function configureClaude(manifest: ServiceManifest, logger: Logger) {
+  await runBestEffort(
+    'claude',
+    ['mcp', 'remove', '--scope', 'user', 'Multi-CLI'],
+    logger,
+  );
+
+  await executeCommand(
+    'claude',
+    [
+      'mcp',
+      'add',
+      '--scope',
+      'user',
+      '--transport',
+      'http',
+      'Multi-CLI',
+      manifest.transport.url,
+      '--header',
+      `Authorization: Bearer ${manifest.transport.token}`,
+    ],
+    { logger },
+  );
+}
+
+export function isMatchingClaudeConfigOutput(
+  output: string,
+  manifest: ServiceManifest,
+): boolean {
+  return output.includes('Type: http')
+    && output.includes(`URL: ${manifest.transport.url}`)
+    && output.includes(`Authorization: Bearer ${manifest.transport.token}`);
+}
+
+async function inspectClaudeConfig(
+  manifest: ServiceManifest,
+  logger: Logger,
+): Promise<ClaudeConfigInspection> {
+  try {
+    const output = await executeCommand(
+      'claude',
+      ['mcp', 'get', 'Multi-CLI'],
+      { logger },
+    );
+
+    return {
+      present: true,
+      matchesManagedService: isMatchingClaudeConfigOutput(output, manifest),
+    };
+  } catch (error) {
+    logger.debug('claude_config_inspection_failed', { error });
+    return {
+      present: false,
+      matchesManagedService: false,
+    };
+  }
+}
+
+async function registerService(manifest: ServiceManifest, logger: Logger) {
+  switch (manifest.serviceKind) {
+    case 'launchd': {
+      const domain = `gui/${process.getuid?.() ?? 0}`;
+      await runBestEffort(
+        'launchctl',
+        ['bootout', domain, manifest.paths.serviceDefinition],
+        logger,
+      );
+      await executeCommand(
+        'launchctl',
+        ['bootstrap', domain, manifest.paths.serviceDefinition],
+        { logger },
+      );
+      await executeCommand(
+        'launchctl',
+        ['kickstart', '-k', `${domain}/${SERVICE_LABEL}`],
+        { logger },
+      );
+      return;
+    }
+    case 'systemd-user':
+      await executeCommand('systemctl', ['--user', 'daemon-reload'], { logger });
+      await executeCommand('systemctl', ['--user', 'enable', '--now', SYSTEMD_UNIT_NAME], { logger });
+      return;
+    case 'windows-task':
+      await executeCommand(
+        'schtasks',
+        ['/Create', '/TN', WINDOWS_TASK_NAME, '/XML', manifest.paths.serviceDefinition, '/F'],
+        { logger },
+      );
+      await runBestEffort('schtasks', ['/Run', '/TN', WINDOWS_TASK_NAME], logger);
+      return;
+  }
+}
+
+async function unregisterService(manifest: ServiceManifest, logger: Logger) {
+  switch (manifest.serviceKind) {
+    case 'launchd': {
+      const domain = `gui/${process.getuid?.() ?? 0}`;
+      await runBestEffort(
+        'launchctl',
+        ['bootout', domain, manifest.paths.serviceDefinition],
+        logger,
+      );
+      return;
+    }
+    case 'systemd-user':
+      await runBestEffort('systemctl', ['--user', 'disable', '--now', SYSTEMD_UNIT_NAME], logger);
+      await runBestEffort('systemctl', ['--user', 'daemon-reload'], logger);
+      return;
+    case 'windows-task':
+      await runBestEffort('schtasks', ['/Delete', '/TN', WINDOWS_TASK_NAME, '/F'], logger);
+      return;
+  }
+}
+
+async function getServiceStatus(manifest: ServiceManifest, logger: Logger): Promise<string> {
+  try {
+    switch (manifest.serviceKind) {
+      case 'launchd':
+        return await executeCommand(
+          'launchctl',
+          ['print', `gui/${process.getuid?.() ?? 0}/${SERVICE_LABEL}`],
+          { logger },
+        );
+      case 'systemd-user':
+        return await executeCommand('systemctl', ['--user', 'status', SYSTEMD_UNIT_NAME], { logger });
+      case 'windows-task':
+        return await executeCommand('schtasks', ['/Query', '/TN', WINDOWS_TASK_NAME, '/V', '/FO', 'LIST'], { logger });
+    }
+  } catch (error) {
+    return `inactive: ${String(error)}`;
+  }
+}
+
+function renderLauncher(manifest: ServiceManifest): string {
+  return manifest.platform === 'win32'
+    ? renderWindowsLauncher(manifest)
+    : renderPosixLauncher(manifest);
+}
+
+function renderServiceDefinition(manifest: ServiceManifest): string {
+  switch (manifest.serviceKind) {
+    case 'launchd':
+      return renderLaunchAgent(manifest);
+    case 'systemd-user':
+      return renderSystemdUnit(manifest);
+    case 'windows-task':
+      return renderWindowsTaskXml(manifest);
+  }
+}
+
+async function installService(
+  config: MultiCliConfig,
+  logger: Logger,
+  options: ServiceInstallOptions,
+): Promise<ServiceManifest> {
+  const existingToken = options.preserveToken && existsSync(path.join(config.serviceRootDir, 'manifest.json'))
+    ? loadManifest(config).transport.token
+    : undefined;
+  const token = config.httpAuthToken ?? existingToken ?? generateServiceToken();
+  const manifest = createServiceManifest(
+    {
+      ...config,
+      transport: 'http',
+      httpHost: '127.0.0.1',
+      httpAuthToken: token,
+    },
+    token,
+  );
+
+  mkdirSync(manifest.paths.root, { recursive: true });
+  writeTextFile(
+    manifest.paths.envFile,
+    buildServiceEnvFileContents(manifest),
+    0o600,
+  );
+  writeTextFile(
+    manifest.paths.launcher,
+    renderLauncher(manifest),
+    manifest.platform === 'win32' ? undefined : 0o700,
+  );
+  writeTextFile(manifest.paths.serviceDefinition, renderServiceDefinition(manifest), 0o600);
+  writeTextFile(manifest.paths.manifest, `${JSON.stringify(manifest, null, 2)}\n`, 0o600);
+
+  await registerService(manifest, logger);
+  await waitForHealth(manifest, logger);
+
+  if (options.configureClaude) {
+    await configureClaude(manifest, logger);
+  }
+
+  return manifest;
+}
+
+function tailFile(filePath: string, lineCount = 200): string {
+  if (!existsSync(filePath)) {
+    return `Log file not found: ${filePath}`;
+  }
+
+  const contents = readFileSync(filePath, 'utf8');
+  return contents.split('\n').slice(-lineCount).join('\n');
+}
+
+export async function handleServiceCommand(
+  args: string[],
+  config: MultiCliConfig,
+  logger: Logger,
+): Promise<void> {
+  const [subcommand = 'status', ...rest] = args;
+  const configureClaudeFlag = rest.includes('--configure-claude');
+  const serviceLogger = logger.child({ component: 'service' });
+
+  switch (subcommand) {
+    case 'install': {
+      const availability = await detectAvailableClis(
+        config.cliDetectTimeoutMs,
+        serviceLogger.child({ component: 'cliDetector' }),
+      );
+      if (!Object.values(availability).some(Boolean)) {
+        throw new Error('Cannot install the Multi-CLI service because no supported backend CLIs were detected on PATH.');
+      }
+
+      const manifest = await installService(config, serviceLogger, {
+        configureClaude: configureClaudeFlag,
+      });
+      process.stdout.write(
+        [
+          `Installed Multi-CLI service (${manifest.serviceKind}).`,
+          `Service URL: ${manifest.transport.url}`,
+          `Health URL: ${manifest.transport.healthUrl}`,
+          `Launcher: ${manifest.paths.launcher}`,
+          configureClaudeFlag
+            ? 'Claude Code configuration updated.'
+            : 'Run `multicli service refresh --configure-claude` or configure Claude manually if needed.',
+        ].join('\n') + '\n',
+      );
+      return;
+    }
+    case 'refresh': {
+      const manifest = await installService(config, serviceLogger, {
+        configureClaude: configureClaudeFlag,
+        preserveToken: true,
+      });
+      process.stdout.write(`Refreshed Multi-CLI service at ${manifest.transport.url}\n`);
+      return;
+    }
+    case 'uninstall': {
+      const manifest = loadManifest(config);
+      const claudeConfig = await inspectClaudeConfig(manifest, serviceLogger);
+      await unregisterService(manifest, serviceLogger);
+      if (claudeConfig.matchesManagedService) {
+        await runBestEffort('claude', ['mcp', 'remove', '--scope', 'user', 'Multi-CLI'], serviceLogger);
+      }
+      try {
+        unlinkSync(manifest.paths.serviceDefinition);
+      } catch {}
+      rmSync(manifest.paths.root, { recursive: true, force: true });
+      process.stdout.write('Uninstalled Multi-CLI service.\n');
+      return;
+    }
+    case 'start': {
+      const manifest = loadManifest(config);
+      await registerService(manifest, serviceLogger);
+      await waitForHealth(manifest, serviceLogger);
+      process.stdout.write(`Started Multi-CLI service at ${manifest.transport.url}\n`);
+      return;
+    }
+    case 'stop': {
+      const manifest = loadManifest(config);
+      await unregisterService(manifest, serviceLogger);
+      process.stdout.write('Stopped Multi-CLI service.\n');
+      return;
+    }
+    case 'restart': {
+      const manifest = loadManifest(config);
+      await unregisterService(manifest, serviceLogger);
+      await registerService(manifest, serviceLogger);
+      await waitForHealth(manifest, serviceLogger);
+      process.stdout.write(`Restarted Multi-CLI service at ${manifest.transport.url}\n`);
+      return;
+    }
+    case 'status': {
+      const manifest = loadManifest(config);
+      const status = await getServiceStatus(manifest, serviceLogger);
+      process.stdout.write(`${status}\n`);
+      return;
+    }
+    case 'doctor': {
+      const manifest = loadManifest(config);
+      const status = await getServiceStatus(manifest, serviceLogger);
+      const claudeConfig = await inspectClaudeConfig(manifest, serviceLogger);
+      let health = 'unreachable';
+      try {
+        const response = await fetch(manifest.transport.healthUrl);
+        health = response.ok ? 'ok' : `http ${response.status}`;
+      } catch (error) {
+        health = `error: ${String(error)}`;
+      }
+
+      const availability = await detectAvailableClis(
+        config.cliDetectTimeoutMs,
+        serviceLogger.child({ component: 'cliDetector' }),
+      );
+
+      process.stdout.write(
+        [
+          'Multi-CLI Doctor',
+          `service kind: ${manifest.serviceKind}`,
+          `service url: ${manifest.transport.url}`,
+          `health: ${health}`,
+          `status: ${status.split('\n')[0] ?? status}`,
+          `launcher: ${manifest.paths.launcher}`,
+          `manifest: ${manifest.paths.manifest}`,
+          `claude config present: ${claudeConfig.present ? 'yes' : 'no'}`,
+          `claude config matches managed service: ${claudeConfig.matchesManagedService ? 'yes' : 'no'}`,
+          `backend clis: ${JSON.stringify(availability)}`,
+        ].join('\n') + '\n',
+      );
+      return;
+    }
+    case 'logs': {
+      const manifest = loadManifest(config);
+      process.stdout.write(`${tailFile(manifest.paths.logFile)}\n`);
+      return;
+    }
+    default:
+      throw new Error(`Unknown service subcommand: ${subcommand}`);
+  }
+}

--- a/src/service/paths.ts
+++ b/src/service/paths.ts
@@ -32,7 +32,7 @@ export function getServicePaths(
     case 'darwin':
       return {
         root,
-        manifest: path.join(root, 'manifest.json'),
+        manifest: config.serviceManifestPath,
         envFile: config.serviceEnvPath,
         launcher: path.join(root, 'Multi-CLI.sh'),
         serviceDefinition: path.join(
@@ -47,7 +47,7 @@ export function getServicePaths(
     case 'win32':
       return {
         root,
-        manifest: path.join(root, 'manifest.json'),
+        manifest: config.serviceManifestPath,
         envFile: config.serviceEnvPath,
         launcher: path.join(root, 'launcher.ps1'),
         serviceDefinition: path.join(root, 'task.xml'),
@@ -57,7 +57,7 @@ export function getServicePaths(
     default:
       return {
         root,
-        manifest: path.join(root, 'manifest.json'),
+        manifest: config.serviceManifestPath,
         envFile: config.serviceEnvPath,
         launcher: path.join(root, 'launcher.sh'),
         serviceDefinition: path.join(

--- a/src/service/paths.ts
+++ b/src/service/paths.ts
@@ -1,0 +1,73 @@
+import os from 'node:os';
+import path from 'node:path';
+
+import type { MultiCliConfig } from '../config.js';
+import type { ServiceKind, ServicePaths } from './types.js';
+
+export const SERVICE_LABEL = 'com.osanoai.multicli';
+export const SYSTEMD_UNIT_NAME = 'multicli.service';
+export const WINDOWS_TASK_NAME = 'MultiCLI';
+
+export function getServiceKind(
+  platform: NodeJS.Platform = process.platform,
+): ServiceKind {
+  switch (platform) {
+    case 'darwin':
+      return 'launchd';
+    case 'win32':
+      return 'windows-task';
+    default:
+      return 'systemd-user';
+  }
+}
+
+export function getServicePaths(
+  config: MultiCliConfig,
+  platform: NodeJS.Platform = process.platform,
+  env: NodeJS.ProcessEnv = process.env,
+): ServicePaths {
+  const root = config.serviceRootDir;
+
+  switch (platform) {
+    case 'darwin':
+      return {
+        root,
+        manifest: path.join(root, 'manifest.json'),
+        envFile: config.serviceEnvPath,
+        launcher: path.join(root, 'Multi-CLI.sh'),
+        serviceDefinition: path.join(
+          os.homedir(),
+          'Library',
+          'LaunchAgents',
+          `${SERVICE_LABEL}.plist`,
+        ),
+        logFile: config.serviceLogPath,
+        stderrLogFile: `${config.serviceLogPath}.stderr`,
+      };
+    case 'win32':
+      return {
+        root,
+        manifest: path.join(root, 'manifest.json'),
+        envFile: config.serviceEnvPath,
+        launcher: path.join(root, 'launcher.ps1'),
+        serviceDefinition: path.join(root, 'task.xml'),
+        logFile: config.serviceLogPath,
+        stderrLogFile: `${config.serviceLogPath}.stderr`,
+      };
+    default:
+      return {
+        root,
+        manifest: path.join(root, 'manifest.json'),
+        envFile: config.serviceEnvPath,
+        launcher: path.join(root, 'launcher.sh'),
+        serviceDefinition: path.join(
+          env.XDG_CONFIG_HOME ?? path.join(os.homedir(), '.config'),
+          'systemd',
+          'user',
+          SYSTEMD_UNIT_NAME,
+        ),
+        logFile: config.serviceLogPath,
+        stderrLogFile: `${config.serviceLogPath}.stderr`,
+      };
+  }
+}

--- a/src/service/renderers.ts
+++ b/src/service/renderers.ts
@@ -1,0 +1,126 @@
+import path from 'node:path';
+
+import type { ServiceManifest } from './types.js';
+
+function escapeXml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&apos;');
+}
+
+function quotePosix(value: string): string {
+  return `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
+function quotePowerShell(value: string): string {
+  return `'${value.replaceAll("'", "''")}'`;
+}
+
+export function renderPosixLauncher(manifest: ServiceManifest): string {
+  return `#!/bin/sh
+set -eu
+
+exec ${quotePosix(manifest.runtime.nodePath)} ${quotePosix(manifest.runtime.bootstrapPath)} ${quotePosix(manifest.paths.envFile)} ${quotePosix(manifest.runtime.entrypointPath)} serve-http
+`;
+}
+
+export function renderWindowsLauncher(manifest: ServiceManifest): string {
+  return `$ErrorActionPreference = 'Stop'
+
+& ${quotePowerShell(manifest.runtime.nodePath)} ${quotePowerShell(manifest.runtime.bootstrapPath)} ${quotePowerShell(manifest.paths.envFile)} ${quotePowerShell(manifest.runtime.entrypointPath)} 'serve-http'
+exit $LASTEXITCODE
+`;
+}
+
+export function renderLaunchAgent(manifest: ServiceManifest): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${escapeXml(manifest.label)}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>${escapeXml(manifest.paths.launcher)}</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>WorkingDirectory</key>
+  <string>${escapeXml(manifest.paths.root)}</string>
+  <key>StandardOutPath</key>
+  <string>${escapeXml(manifest.paths.logFile)}</string>
+  <key>StandardErrorPath</key>
+  <string>${escapeXml(manifest.paths.stderrLogFile)}</string>
+</dict>
+</plist>
+`;
+}
+
+export function renderSystemdUnit(manifest: ServiceManifest): string {
+  return `[Unit]
+Description=Multi-CLI local HTTP service
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=${JSON.stringify(manifest.paths.root)}
+ExecStart=${JSON.stringify(manifest.paths.launcher)}
+Restart=on-failure
+RestartSec=1
+StandardOutput=append:${JSON.stringify(manifest.paths.logFile)}
+StandardError=append:${JSON.stringify(manifest.paths.stderrLogFile)}
+
+[Install]
+WantedBy=default.target
+`;
+}
+
+export function renderWindowsTaskXml(manifest: ServiceManifest): string {
+  const command = path.join(
+    process.env.SystemRoot ?? 'C:\\Windows',
+    'System32',
+    'WindowsPowerShell',
+    'v1.0',
+    'powershell.exe',
+  );
+  const argumentsText = `-NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -File ${quotePowerShell(manifest.paths.launcher)}`;
+
+  return `<?xml version="1.0" encoding="UTF-16"?>
+<Task version="1.4" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
+  <Triggers>
+    <LogonTrigger>
+      <Enabled>true</Enabled>
+    </LogonTrigger>
+  </Triggers>
+  <Principals>
+    <Principal id="Author">
+      <LogonType>InteractiveToken</LogonType>
+      <RunLevel>LeastPrivilege</RunLevel>
+    </Principal>
+  </Principals>
+  <Settings>
+    <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>
+    <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>
+    <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>
+    <AllowHardTerminate>true</AllowHardTerminate>
+    <StartWhenAvailable>true</StartWhenAvailable>
+    <RestartOnFailure>
+      <Interval>PT1M</Interval>
+      <Count>3</Count>
+    </RestartOnFailure>
+  </Settings>
+  <Actions Context="Author">
+    <Exec>
+      <Command>${escapeXml(command)}</Command>
+      <Arguments>${escapeXml(argumentsText)}</Arguments>
+      <WorkingDirectory>${escapeXml(manifest.paths.root)}</WorkingDirectory>
+    </Exec>
+  </Actions>
+</Task>
+`;
+}

--- a/src/service/runtime.ts
+++ b/src/service/runtime.ts
@@ -1,0 +1,167 @@
+import { randomBytes } from 'node:crypto';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import type { MultiCliConfig } from '../config.js';
+import type { ServiceManifest, ServicePaths } from './types.js';
+import { SERVICE_LABEL, WINDOWS_TASK_NAME, getServiceKind, getServicePaths } from './paths.js';
+
+const MANAGED_ENV_KEYS = [
+  'PATH',
+  'HOME',
+  'USER',
+  'SHELL',
+  'OPENAI_API_KEY',
+  'ANTHROPIC_API_KEY',
+  'GEMINI_API_KEY',
+  'GOOGLE_API_KEY',
+  'GOOGLE_CLOUD_PROJECT',
+  'GOOGLE_APPLICATION_CREDENTIALS',
+  'VERTEXAI_LOCATION',
+  'AWS_PROFILE',
+  'AWS_REGION',
+  'AWS_DEFAULT_REGION',
+] as const;
+
+function isTransientRuntimePath(targetPath: string): boolean {
+  return targetPath.includes(`${path.sep}_npx${path.sep}`)
+    || targetPath.includes(`${path.sep}npm${path.sep}_npx${path.sep}`);
+}
+
+export function resolveEntrypointPath(): string {
+  const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    path.resolve(moduleDir, '..', 'index.js'),
+    path.resolve(moduleDir, '..', '..', 'dist', 'index.js'),
+  ];
+
+  const existingCandidate = candidates.find((candidate) => existsSync(candidate));
+  if (!existingCandidate) {
+    throw new Error(`Unable to locate a runnable Multi-CLI entrypoint. Tried: ${candidates.join(', ')}`);
+  }
+
+  return existingCandidate;
+}
+
+export function resolveBootstrapPath(): string {
+  const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    path.resolve(moduleDir, '..', '..', 'dist', 'service', 'bootstrap.js'),
+    path.resolve(moduleDir, 'bootstrap.js'),
+    path.resolve(moduleDir, 'bootstrap.ts'),
+  ];
+
+  const existingCandidate = candidates.find((candidate) => existsSync(candidate));
+  if (!existingCandidate) {
+    throw new Error(`Unable to locate the Multi-CLI service bootstrap. Tried: ${candidates.join(', ')}`);
+  }
+
+  return existingCandidate;
+}
+
+export function resolveServiceRuntime(): {
+  nodePath: string;
+  bootstrapPath: string;
+  entrypointPath: string;
+  packageVersion: string;
+} {
+  const nodePath = process.execPath;
+  const bootstrapPath = resolveBootstrapPath();
+  const entrypointPath = resolveEntrypointPath();
+
+  if (isTransientRuntimePath(nodePath) || isTransientRuntimePath(bootstrapPath) || isTransientRuntimePath(entrypointPath)) {
+    throw new Error(
+      'Service install cannot use a transient npx runtime. Install Multi-CLI globally or run it from a stable local checkout first.',
+    );
+  }
+
+  if (!existsSync(nodePath)) {
+    throw new Error(`Node runtime does not exist: ${nodePath}`);
+  }
+
+  if (!existsSync(bootstrapPath)) {
+    throw new Error(`Bootstrap entrypoint does not exist: ${bootstrapPath}`);
+  }
+
+  if (!existsSync(entrypointPath)) {
+    throw new Error(`Entrypoint does not exist: ${entrypointPath}`);
+  }
+
+  return {
+    nodePath,
+    bootstrapPath,
+    entrypointPath,
+    packageVersion: process.env.npm_package_version || 'unknown',
+  };
+}
+
+export function generateServiceToken(): string {
+  return randomBytes(32).toString('hex');
+}
+
+export function buildServiceEnvFileContents(
+  manifest: ServiceManifest,
+  currentEnv: NodeJS.ProcessEnv = process.env,
+): string {
+  const managedEntries: Record<string, string> = {
+    MULTICLI_TRANSPORT: 'http',
+    MULTICLI_HTTP_HOST: manifest.transport.host,
+    MULTICLI_HTTP_PORT: String(manifest.transport.port),
+    MULTICLI_HTTP_PATH: manifest.transport.path,
+    MULTICLI_HTTP_AUTH_TOKEN: manifest.transport.token,
+    MULTICLI_LOG_PATH: manifest.paths.logFile,
+    MULTICLI_SERVICE_ROOT_DIR: manifest.paths.root,
+    MULTICLI_SERVICE_LOG_PATH: manifest.paths.logFile,
+    MULTICLI_SERVICE_ENV_PATH: manifest.paths.envFile,
+    MULTICLI_SERVICE_RUNTIME_PATH: manifest.paths.manifest,
+  };
+
+  const envEntries: Record<string, string> = {};
+
+  const currentPath = currentEnv.PATH ?? '';
+  if (currentPath) {
+    envEntries.PATH = currentPath;
+  }
+
+  for (const key of MANAGED_ENV_KEYS) {
+    if (key === 'PATH') {
+      continue;
+    }
+    const value = currentEnv[key];
+    if (value) {
+      envEntries[key] = value;
+    }
+  }
+
+  return `${JSON.stringify({ ...envEntries, ...managedEntries }, null, 2)}\n`;
+}
+
+export function createServiceManifest(
+  config: MultiCliConfig,
+  token: string,
+  platform: NodeJS.Platform = process.platform,
+): ServiceManifest {
+  const serviceKind = getServiceKind(platform);
+  const paths: ServicePaths = getServicePaths(config, platform, process.env);
+  const runtime = resolveServiceRuntime();
+  const url = `http://${config.httpHost}:${config.httpPort}${config.httpPath}`;
+
+  return {
+    schemaVersion: 1,
+    label: platform === 'win32' ? WINDOWS_TASK_NAME : SERVICE_LABEL,
+    platform,
+    serviceKind,
+    installedAt: new Date().toISOString(),
+    runtime,
+    transport: {
+      host: config.httpHost,
+      port: config.httpPort,
+      path: config.httpPath,
+      token,
+      url,
+      healthUrl: `http://${config.httpHost}:${config.httpPort}/health`,
+    },
+    paths,
+  };
+}

--- a/src/service/runtime.ts
+++ b/src/service/runtime.ts
@@ -114,7 +114,7 @@ export function buildServiceEnvFileContents(
     MULTICLI_SERVICE_ROOT_DIR: manifest.paths.root,
     MULTICLI_SERVICE_LOG_PATH: manifest.paths.logFile,
     MULTICLI_SERVICE_ENV_PATH: manifest.paths.envFile,
-    MULTICLI_SERVICE_RUNTIME_PATH: manifest.paths.manifest,
+    MULTICLI_SERVICE_MANIFEST_PATH: manifest.paths.manifest,
   };
 
   const envEntries: Record<string, string> = {};

--- a/src/service/types.ts
+++ b/src/service/types.ts
@@ -1,0 +1,34 @@
+export type ServiceKind = 'launchd' | 'systemd-user' | 'windows-task';
+
+export interface ServicePaths {
+  root: string;
+  manifest: string;
+  envFile: string;
+  launcher: string;
+  serviceDefinition: string;
+  logFile: string;
+  stderrLogFile: string;
+}
+
+export interface ServiceManifest {
+  schemaVersion: 1;
+  label: string;
+  platform: NodeJS.Platform;
+  serviceKind: ServiceKind;
+  installedAt: string;
+  runtime: {
+    nodePath: string;
+    bootstrapPath: string;
+    entrypointPath: string;
+    packageVersion: string;
+  };
+  transport: {
+    host: string;
+    port: number;
+    path: string;
+    token: string;
+    url: string;
+    healthUrl: string;
+  };
+  paths: ServicePaths;
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -11,14 +11,20 @@ import { askClaudeTool } from './ask-claude.tool.js';
 import { askOpencodeTool } from './ask-opencode.tool.js';
 import { detectAvailableClis, CliAvailability } from '../utils/cliDetector.js';
 import { MultiCliConfig } from '../config.js';
+import type { Logger } from '../logger.js';
 
 /**
  * Initialize the tool registry based on which CLIs are available.
  * Must be called (and awaited) before the server starts accepting requests.
  */
-export async function initTools(config?: Pick<MultiCliConfig, 'cliDetectTimeoutMs'>): Promise<CliAvailability> {
+export async function initTools(
+  config?: Pick<MultiCliConfig, 'cliDetectTimeoutMs'> & { logger?: Logger },
+): Promise<CliAvailability> {
   toolRegistry.length = 0;
-  const availability = await detectAvailableClis(config?.cliDetectTimeoutMs);
+  const availability = await detectAvailableClis(
+    config?.cliDetectTimeoutMs,
+    config?.logger,
+  );
 
   if (availability.gemini) {
     toolRegistry.push(
@@ -52,6 +58,11 @@ export async function initTools(config?: Pick<MultiCliConfig, 'cliDetectTimeoutM
       opencodeHelpTool,       // OpenCode-Help
     );
   }
+
+  config?.logger?.info('tool_registry_initialized', {
+    availability,
+    toolNames: toolRegistry.map((tool) => tool.name),
+  });
 
   return availability;
 }

--- a/src/utils/cliDetector.ts
+++ b/src/utils/cliDetector.ts
@@ -1,5 +1,6 @@
 import { spawn } from "child_process";
 import { CLI } from "../constants.js";
+import type { Logger } from "../logger.js";
 
 const isWindows = process.platform === "win32";
 
@@ -8,10 +9,19 @@ const isWindows = process.platform === "win32";
  * Uses `which` on Unix/macOS, `where` on Windows.
  * Always resolves to a boolean — never rejects.
  */
-export async function commandExists(command: string, timeoutMs?: number): Promise<boolean> {
+export async function commandExists(
+  command: string,
+  timeoutMs?: number,
+  logger?: Logger,
+): Promise<boolean> {
   return new Promise((resolve) => {
     try {
       const checker = isWindows ? "where" : "which";
+      logger?.debug('cli_probe_started', {
+        command,
+        checker,
+        timeoutMs,
+      });
       const child = spawn(checker, [command], {
         stdio: ["ignore", "ignore", "ignore"],
         shell: isWindows,
@@ -27,20 +37,40 @@ export async function commandExists(command: string, timeoutMs?: number): Promis
       if (timeoutMs && timeoutMs > 0) {
         timeoutId = setTimeout(() => {
           child.kill('SIGTERM');
+          logger?.error('cli_probe_timed_out', {
+            command,
+            checker,
+            timeoutMs,
+          });
           resolve(false);
         }, timeoutMs);
       }
 
-      child.on("error", () => {
+      child.on("error", (error) => {
         cleanup();
+        logger?.error('cli_probe_spawn_failed', {
+          command,
+          checker,
+          error,
+        });
         resolve(false);
       });
 
       child.on("close", (code) => {
         cleanup();
+        logger?.debug('cli_probe_finished', {
+          command,
+          checker,
+          exitCode: code,
+          exists: code === 0,
+        });
         resolve(code === 0);
       });
-    } catch {
+    } catch (error) {
+      logger?.error('cli_probe_threw', {
+        command,
+        error,
+      });
       resolve(false);
     }
   });
@@ -57,19 +87,27 @@ export interface CliAvailability {
  * Detect which of the four supported CLIs are available on the system.
  * Runs all four checks in parallel for speed.
  */
-export async function detectAvailableClis(timeoutMs?: number): Promise<CliAvailability> {
+export async function detectAvailableClis(
+  timeoutMs?: number,
+  logger?: Logger,
+): Promise<CliAvailability> {
   if (process.env.QA_NO_CLIS === 'true') {
+    logger?.info('cli_detection_skipped', {
+      reason: 'QA_NO_CLIS=true',
+    });
     return { gemini: false, codex: false, claude: false, opencode: false };
   }
 
+  logger?.info('cli_detection_started', { timeoutMs });
   const [gemini, codex, claude, opencode] = await Promise.all([
-    commandExists(CLI.COMMANDS.GEMINI, timeoutMs),
-    commandExists(CLI.COMMANDS.CODEX, timeoutMs),
-    commandExists(CLI.COMMANDS.CLAUDE, timeoutMs),
-    commandExists(CLI.COMMANDS.OPENCODE, timeoutMs),
+    commandExists(CLI.COMMANDS.GEMINI, timeoutMs, logger),
+    commandExists(CLI.COMMANDS.CODEX, timeoutMs, logger),
+    commandExists(CLI.COMMANDS.CLAUDE, timeoutMs, logger),
+    commandExists(CLI.COMMANDS.OPENCODE, timeoutMs, logger),
   ]);
 
   const availability: CliAvailability = { gemini, codex, claude, opencode };
+  logger?.info('cli_detection_finished', { availability });
 
   return availability;
 }

--- a/src/utils/commandExecutor.ts
+++ b/src/utils/commandExecutor.ts
@@ -3,6 +3,7 @@ import { ToolExecutionContext } from "../execution.js";
 
 // Detect Windows platform for shell compatibility
 const isWindows = process.platform === "win32";
+const SENSITIVE_VALUE_FLAGS = new Set(['--header', '-H', '--token', '--api-key', '--apikey', '--auth-token']);
 
 export type CommandExecutionFailureKind =
   | "cancelled"
@@ -69,6 +70,51 @@ export function sanitizeArgForCmd(arg: string): string {
   }
 }
 
+function redactSensitiveText(text: string): string {
+  return text
+    .replace(/(Authorization:\s*Bearer\s+)[^\s'"]+/gi, '$1[Redacted]')
+    .replace(/(X-API-Key:\s*)[^\s'"]+/gi, '$1[Redacted]')
+    .replace(/("authorization"\s*:\s*")([^"]+)(")/gi, '$1[Redacted]$3')
+    .replace(/("token"\s*:\s*")([^"]+)(")/gi, '$1[Redacted]$3');
+}
+
+function redactArgValueForLogging(flag: string, value: string): string {
+  if (flag === '--header' || flag === '-H') {
+    return redactSensitiveText(value);
+  }
+
+  return '[Redacted]';
+}
+
+function redactArgsForLogging(args: string[]): string[] {
+  const redacted: string[] = [];
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    const equalsIndex = arg.indexOf('=');
+
+    if (equalsIndex > 0) {
+      const flag = arg.slice(0, equalsIndex);
+      const value = arg.slice(equalsIndex + 1);
+      if (SENSITIVE_VALUE_FLAGS.has(flag)) {
+        redacted.push(`${flag}=${redactArgValueForLogging(flag, value)}`);
+        continue;
+      }
+    }
+
+    if (SENSITIVE_VALUE_FLAGS.has(arg) && index + 1 < args.length) {
+      redacted.push(arg);
+      redacted.push(redactArgValueForLogging(arg, args[index + 1]));
+      index += 1;
+      continue;
+    }
+
+    redacted.push(redactSensitiveText(arg));
+  }
+
+  return redacted;
+}
+
 function terminateWindowsProcessTree(pid: number, force: boolean) {
   const killArgs = ["/pid", String(pid), "/T"];
   if (force) {
@@ -117,10 +163,12 @@ export async function executeCommand(
     // Use shell: true on Windows to properly execute .cmd files and resolve PATH.
     // Sanitize args to prevent cmd.exe metacharacter injection.
     const safeArgs = isWindows ? args.map(sanitizeArgForCmd) : args;
+    const loggedArgs = redactArgsForLogging(args);
+    const loggedSafeArgs = redactArgsForLogging(safeArgs);
     logger?.info("command_spawn_requested", {
       command,
-      args,
-      safeArgs,
+      args: loggedArgs,
+      safeArgs: loggedSafeArgs,
       cwd,
       timeoutMs,
       killGraceMs,
@@ -149,7 +197,7 @@ export async function executeCommand(
 
     logger?.info("command_spawned", {
       command,
-      args,
+      args: loggedArgs,
       cwd,
       pid: childProcess.pid,
     });
@@ -169,7 +217,7 @@ export async function executeCommand(
     const abortListener = () => {
         logger?.error("command_abort_signal_received", {
           command,
-          args,
+          args: loggedArgs,
           cwd,
           pid: childProcess.pid,
           signalReason: signal?.reason,
@@ -178,7 +226,12 @@ export async function executeCommand(
         new CommandExecutionError(
           "cancelled",
           "Command cancelled",
-          { command, args, stdout, stderr },
+          {
+            command,
+            args: loggedArgs,
+            stdout: redactSensitiveText(stdout),
+            stderr: redactSensitiveText(stderr),
+          },
         ),
       );
     };
@@ -202,7 +255,7 @@ export async function executeCommand(
         terminationStarted = true;
         logger?.error("command_termination_started", {
           command,
-          args,
+          args: loggedArgs,
           cwd,
           pid: childProcess.pid,
           reason: error.message,
@@ -213,7 +266,7 @@ export async function executeCommand(
           if (childProcess.pid) {
             logger?.error("command_termination_escalated", {
               command,
-              args,
+              args: loggedArgs,
               cwd,
               pid: childProcess.pid,
               killGraceMs,
@@ -235,14 +288,14 @@ export async function executeCommand(
     if (timeoutMs && timeoutMs > 0) {
       logger?.debug("command_timeout_started", {
         command,
-        args,
+        args: loggedArgs,
         cwd,
         timeoutMs,
       });
       timeoutId = setTimeout(() => {
         logger?.error("command_timeout_elapsed", {
           command,
-          args,
+          args: loggedArgs,
           cwd,
           pid: childProcess.pid,
           timeoutMs,
@@ -251,7 +304,12 @@ export async function executeCommand(
           new CommandExecutionError(
             "timeout",
             `Command timed out after ${timeoutMs}ms`,
-            { command, args, stdout, stderr },
+            {
+              command,
+              args: loggedArgs,
+              stdout: redactSensitiveText(stdout),
+              stderr: redactSensitiveText(stderr),
+            },
           ),
         );
       }, timeoutMs);
@@ -262,14 +320,15 @@ export async function executeCommand(
       const chunk = data.toString();
       stdout += chunk;
       stdoutChunkCount += 1;
+      const loggedChunk = redactSensitiveText(chunk);
       logger?.debug("command_stdout_chunk", {
         command,
-        args,
+        args: loggedArgs,
         cwd,
         pid: childProcess.pid,
         chunkIndex: stdoutChunkCount,
         chunkLength: chunk.length,
-        chunk,
+        chunk: loggedChunk,
       });
 
       // Report new content if callback provided
@@ -287,29 +346,35 @@ export async function executeCommand(
       const chunk = data.toString();
       stderr += chunk;
       stderrChunkCount += 1;
+      const loggedChunk = redactSensitiveText(chunk);
       logger?.debug("command_stderr_chunk", {
         command,
-        args,
+        args: loggedArgs,
         cwd,
         pid: childProcess.pid,
         chunkIndex: stderrChunkCount,
         chunkLength: chunk.length,
-        chunk,
+        chunk: loggedChunk,
       });
 
       if (stderr.includes("RESOURCE_EXHAUSTED")) {
         logger?.error("command_quota_exhausted", {
           command,
-          args,
+          args: loggedArgs,
           cwd,
           pid: childProcess.pid,
-          stderr,
+          stderr: redactSensitiveText(stderr),
         });
         beginTermination(
           new CommandExecutionError(
             "quota",
-            `Command failed due to quota exhaustion: ${stderr.trim()}`,
-            { command, args, stdout, stderr },
+            `Command failed due to quota exhaustion: ${redactSensitiveText(stderr).trim()}`,
+            {
+              command,
+              args: loggedArgs,
+              stdout: redactSensitiveText(stdout),
+              stderr: redactSensitiveText(stderr),
+            },
           ),
         );
       }
@@ -321,7 +386,7 @@ export async function executeCommand(
         signal?.removeEventListener("abort", abortListener);
         logger?.error("command_spawn_failed", {
           command,
-          args,
+          args: loggedArgs,
           cwd,
           pid: childProcess.pid,
           error,
@@ -330,7 +395,12 @@ export async function executeCommand(
           new CommandExecutionError(
             "spawn",
             `Failed to spawn command: ${error.message}`,
-            { command, args, stdout, stderr },
+            {
+              command,
+              args: loggedArgs,
+              stdout: redactSensitiveText(stdout),
+              stderr: redactSensitiveText(stderr),
+            },
           ),
         );
       }
@@ -342,7 +412,7 @@ export async function executeCommand(
 
        logger?.info("command_closed", {
         command,
-        args,
+        args: loggedArgs,
         cwd,
         pid: childProcess.pid,
         exitCode: code,
@@ -362,7 +432,7 @@ export async function executeCommand(
         if (output || !stderr.trim()) {
           logger?.info("command_completed", {
             command,
-            args,
+            args: loggedArgs,
             cwd,
             pid: childProcess.pid,
             exitCode: code,
@@ -375,37 +445,51 @@ export async function executeCommand(
 
         logger?.error("command_completed_without_stdout", {
           command,
-          args,
+          args: loggedArgs,
           cwd,
           pid: childProcess.pid,
           exitCode: code,
-          stderr,
+          stderr: redactSensitiveText(stderr),
         });
         settle(
           new CommandExecutionError(
             "no-output",
-            `Command produced no output. stderr: ${stderr.trim()}`,
-            { command, args, exitCode: code, stdout, stderr },
+            `Command produced no output. stderr: ${redactSensitiveText(stderr).trim()}`,
+            {
+              command,
+              args: loggedArgs,
+              exitCode: code,
+              stdout: redactSensitiveText(stdout),
+              stderr: redactSensitiveText(stderr),
+            },
           ),
         );
         return;
       }
 
-      const errorMessage = stderr.trim() || "Unknown error";
+      const redactedStdout = redactSensitiveText(stdout);
+      const redactedStderr = redactSensitiveText(stderr);
+      const errorMessage = redactedStderr.trim() || "Unknown error";
       logger?.error("command_failed", {
         command,
-        args,
+        args: loggedArgs,
         cwd,
         pid: childProcess.pid,
         exitCode: code,
-        stderr,
-        stdout,
+        stderr: redactedStderr,
+        stdout: redactedStdout,
       });
       settle(
         new CommandExecutionError(
           stderr.includes("RESOURCE_EXHAUSTED") ? "quota" : "failed",
           `Command failed with exit code ${code}: ${errorMessage}`,
-          { command, args, exitCode: code, stdout, stderr },
+          {
+            command,
+            args: loggedArgs,
+            exitCode: code,
+            stdout: redactedStdout,
+            stderr: redactedStderr,
+          },
         ),
       );
     });

--- a/src/utils/commandExecutor.ts
+++ b/src/utils/commandExecutor.ts
@@ -103,14 +103,35 @@ export async function executeCommand(
   args: string[],
   options: ToolExecutionContext = {},
 ): Promise<string> {
-  const { onProgress, signal, timeoutMs, killGraceMs = 5000 } = options;
+  const {
+    onProgress,
+    signal,
+    timeoutMs,
+    killGraceMs = 5000,
+    cwd,
+    env,
+    logger,
+  } = options;
 
   return new Promise((resolve, reject) => {
     // Use shell: true on Windows to properly execute .cmd files and resolve PATH.
     // Sanitize args to prevent cmd.exe metacharacter injection.
     const safeArgs = isWindows ? args.map(sanitizeArgForCmd) : args;
+    logger?.info("command_spawn_requested", {
+      command,
+      args,
+      safeArgs,
+      cwd,
+      timeoutMs,
+      killGraceMs,
+      platform: process.platform,
+      shell: isWindows,
+      detached: !isWindows,
+      envKeys: env ? Object.keys(env).sort() : undefined,
+    });
     const childProcess = spawn(command, safeArgs, {
-      env: process.env,
+      cwd,
+      env: env ?? process.env,
       shell: isWindows,
       stdio: ["ignore", "pipe", "pipe"],
       detached: !isWindows,
@@ -123,6 +144,15 @@ export async function executeCommand(
     let timeoutId: ReturnType<typeof setTimeout> | undefined;
     let forceKillTimeoutId: ReturnType<typeof setTimeout> | undefined;
     let terminationStarted = false;
+    let stdoutChunkCount = 0;
+    let stderrChunkCount = 0;
+
+    logger?.info("command_spawned", {
+      command,
+      args,
+      cwd,
+      pid: childProcess.pid,
+    });
 
     const clearRequestTimer = () => {
       if (timeoutId) {
@@ -137,6 +167,13 @@ export async function executeCommand(
     };
 
     const abortListener = () => {
+        logger?.error("command_abort_signal_received", {
+          command,
+          args,
+          cwd,
+          pid: childProcess.pid,
+          signalReason: signal?.reason,
+        });
       beginTermination(
         new CommandExecutionError(
           "cancelled",
@@ -163,9 +200,24 @@ export async function executeCommand(
     const beginTermination = (error: Error) => {
       if (!terminationStarted && childProcess.pid) {
         terminationStarted = true;
+        logger?.error("command_termination_started", {
+          command,
+          args,
+          cwd,
+          pid: childProcess.pid,
+          reason: error.message,
+          error,
+        });
         terminateChildProcess(childProcess.pid, false);
         forceKillTimeoutId = setTimeout(() => {
           if (childProcess.pid) {
+            logger?.error("command_termination_escalated", {
+              command,
+              args,
+              cwd,
+              pid: childProcess.pid,
+              killGraceMs,
+            });
             terminateChildProcess(childProcess.pid, true);
           }
         }, killGraceMs);
@@ -175,9 +227,26 @@ export async function executeCommand(
     };
 
     signal?.addEventListener("abort", abortListener, { once: true });
+    if (signal?.aborted) {
+      abortListener();
+      return;
+    }
 
     if (timeoutMs && timeoutMs > 0) {
+      logger?.debug("command_timeout_started", {
+        command,
+        args,
+        cwd,
+        timeoutMs,
+      });
       timeoutId = setTimeout(() => {
+        logger?.error("command_timeout_elapsed", {
+          command,
+          args,
+          cwd,
+          pid: childProcess.pid,
+          timeoutMs,
+        });
         beginTermination(
           new CommandExecutionError(
             "timeout",
@@ -190,7 +259,18 @@ export async function executeCommand(
 
     childProcess.stdout?.on("data", (data) => {
       if (isSettled) return;
-      stdout += data.toString();
+      const chunk = data.toString();
+      stdout += chunk;
+      stdoutChunkCount += 1;
+      logger?.debug("command_stdout_chunk", {
+        command,
+        args,
+        cwd,
+        pid: childProcess.pid,
+        chunkIndex: stdoutChunkCount,
+        chunkLength: chunk.length,
+        chunk,
+      });
 
       // Report new content if callback provided
       if (onProgress && stdout.length > lastReportedLength) {
@@ -204,9 +284,27 @@ export async function executeCommand(
     // CLI level errors
     childProcess.stderr?.on("data", (data) => {
       if (isSettled) return;
-      stderr += data.toString();
+      const chunk = data.toString();
+      stderr += chunk;
+      stderrChunkCount += 1;
+      logger?.debug("command_stderr_chunk", {
+        command,
+        args,
+        cwd,
+        pid: childProcess.pid,
+        chunkIndex: stderrChunkCount,
+        chunkLength: chunk.length,
+        chunk,
+      });
 
       if (stderr.includes("RESOURCE_EXHAUSTED")) {
+        logger?.error("command_quota_exhausted", {
+          command,
+          args,
+          cwd,
+          pid: childProcess.pid,
+          stderr,
+        });
         beginTermination(
           new CommandExecutionError(
             "quota",
@@ -221,6 +319,13 @@ export async function executeCommand(
         clearRequestTimer();
         clearTerminationTimer();
         signal?.removeEventListener("abort", abortListener);
+        logger?.error("command_spawn_failed", {
+          command,
+          args,
+          cwd,
+          pid: childProcess.pid,
+          error,
+        });
         settle(
           new CommandExecutionError(
             "spawn",
@@ -235,6 +340,19 @@ export async function executeCommand(
       clearTerminationTimer();
       signal?.removeEventListener("abort", abortListener);
 
+       logger?.info("command_closed", {
+        command,
+        args,
+        cwd,
+        pid: childProcess.pid,
+        exitCode: code,
+        stdoutLength: stdout.length,
+        stderrLength: stderr.length,
+        stdoutChunkCount,
+        stderrChunkCount,
+        settledEarly: isSettled,
+      });
+
       if (isSettled) {
         return;
       }
@@ -242,10 +360,27 @@ export async function executeCommand(
       if (code === 0) {
         const output = stdout.trim();
         if (output || !stderr.trim()) {
+          logger?.info("command_completed", {
+            command,
+            args,
+            cwd,
+            pid: childProcess.pid,
+            exitCode: code,
+            resultKind: "success",
+            outputLength: output.length,
+          });
           settle(undefined, output);
           return;
         }
 
+        logger?.error("command_completed_without_stdout", {
+          command,
+          args,
+          cwd,
+          pid: childProcess.pid,
+          exitCode: code,
+          stderr,
+        });
         settle(
           new CommandExecutionError(
             "no-output",
@@ -257,6 +392,15 @@ export async function executeCommand(
       }
 
       const errorMessage = stderr.trim() || "Unknown error";
+      logger?.error("command_failed", {
+        command,
+        args,
+        cwd,
+        pid: childProcess.pid,
+        exitCode: code,
+        stderr,
+        stdout,
+      });
       settle(
         new CommandExecutionError(
           stderr.includes("RESOURCE_EXHAUSTED") ? "quota" : "failed",

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -20,6 +20,9 @@ describe('config', () => {
     );
     expect(config.serviceRootDir.toLowerCase()).toContain('multicli');
     expect(config.serviceEnvPath).toContain(config.serviceRootDir);
+    expect(config.serviceManifestPath).toBe(
+      path.join(config.serviceRootDir, 'manifest.json'),
+    );
   });
 
   it('allows log path and stderr level overrides from the environment', () => {
@@ -43,6 +46,7 @@ describe('config', () => {
       MULTICLI_HTTP_AUTH_TOKEN: 'secret-token',
       MULTICLI_HTTP_SESSION_IDLE_MS: '60000',
       MULTICLI_SERVICE_ROOT_DIR: '/tmp/multicli-service',
+      MULTICLI_SERVICE_MANIFEST_PATH: '/tmp/multicli-service/custom-manifest.json',
     });
 
     expect(config.transport).toBe('http');
@@ -53,5 +57,15 @@ describe('config', () => {
     expect(config.httpSessionIdleMs).toBe(60000);
     expect(config.serviceRootDir).toBe('/tmp/multicli-service');
     expect(config.serviceLogPath).toBe('/tmp/multicli-service/logs/service.log');
+    expect(config.serviceManifestPath).toBe('/tmp/multicli-service/custom-manifest.json');
+  });
+
+  it('accepts the legacy runtime-path env var as a manifest-path alias', () => {
+    const config = loadConfig({
+      MULTICLI_SERVICE_ROOT_DIR: '/tmp/multicli-service',
+      MULTICLI_SERVICE_RUNTIME_PATH: '/tmp/multicli-service/legacy-manifest.json',
+    });
+
+    expect(config.serviceManifestPath).toBe('/tmp/multicli-service/legacy-manifest.json');
   });
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,0 +1,57 @@
+import os from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { loadConfig } from '../src/config.js';
+
+describe('config', () => {
+  it('uses verbose file logging defaults with a standard log path', () => {
+    const config = loadConfig({});
+
+    expect(config.transport).toBe('stdio');
+    expect(config.httpHost).toBe('127.0.0.1');
+    expect(config.httpPort).toBe(37420);
+    expect(config.httpPath).toBe('/mcp');
+    expect(config.logLevel).toBe('debug');
+    expect(config.stderrLogLevel).toBe('error');
+    expect(config.logPath).toBe(
+      path.join(os.homedir(), '.multicli', 'logs', 'multicli.log'),
+    );
+    expect(config.serviceRootDir.toLowerCase()).toContain('multicli');
+    expect(config.serviceEnvPath).toContain(config.serviceRootDir);
+  });
+
+  it('allows log path and stderr level overrides from the environment', () => {
+    const config = loadConfig({
+      MULTICLI_LOG_PATH: '/tmp/custom-multicli.log',
+      MULTICLI_LOG_LEVEL: 'info',
+      MULTICLI_STDERR_LOG_LEVEL: 'silent',
+    });
+
+    expect(config.logPath).toBe('/tmp/custom-multicli.log');
+    expect(config.logLevel).toBe('info');
+    expect(config.stderrLogLevel).toBe('silent');
+  });
+
+  it('parses HTTP and service configuration from the environment', () => {
+    const config = loadConfig({
+      MULTICLI_TRANSPORT: 'http',
+      MULTICLI_HTTP_HOST: '127.0.0.1',
+      MULTICLI_HTTP_PORT: '40123',
+      MULTICLI_HTTP_PATH: 'custom-mcp',
+      MULTICLI_HTTP_AUTH_TOKEN: 'secret-token',
+      MULTICLI_HTTP_SESSION_IDLE_MS: '60000',
+      MULTICLI_SERVICE_ROOT_DIR: '/tmp/multicli-service',
+    });
+
+    expect(config.transport).toBe('http');
+    expect(config.httpHost).toBe('127.0.0.1');
+    expect(config.httpPort).toBe(40123);
+    expect(config.httpPath).toBe('/custom-mcp');
+    expect(config.httpAuthToken).toBe('secret-token');
+    expect(config.httpSessionIdleMs).toBe(60000);
+    expect(config.serviceRootDir).toBe('/tmp/multicli-service');
+    expect(config.serviceLogPath).toBe('/tmp/multicli-service/logs/service.log');
+  });
+});

--- a/tests/httpServer.test.ts
+++ b/tests/httpServer.test.ts
@@ -1,0 +1,189 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createServer } from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import {
+  CallToolResultSchema,
+  ListRootsRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+
+vi.mock('../src/utils/cliDetector.js', () => ({
+  detectAvailableClis: vi.fn(),
+}));
+
+vi.mock('../src/utils/commandExecutor.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/utils/commandExecutor.js')>();
+  return {
+    ...actual,
+    executeCommand: vi.fn(),
+  };
+});
+
+import { detectAvailableClis } from '../src/utils/cliDetector.js';
+import { executeCommand } from '../src/utils/commandExecutor.js';
+import { startHttpServer } from '../src/httpServer.js';
+import type { MultiCliHttpServer } from '../src/httpServer.js';
+import type { MultiCliConfig } from '../src/config.js';
+
+async function findAvailablePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        reject(new Error('Failed to resolve ephemeral port'));
+        return;
+      }
+
+      const { port } = address;
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve(port);
+      });
+    });
+  });
+}
+
+const canBindLoopback = await new Promise<boolean>((resolve) => {
+  const server = createServer();
+  server.once('error', () => resolve(false));
+  server.listen(0, '127.0.0.1', () => {
+    server.close(() => resolve(true));
+  });
+});
+
+async function createHttpConfig(): Promise<MultiCliConfig> {
+  const port = await findAvailablePort();
+  const serviceRootDir = path.join(os.tmpdir(), `multicli-http-${process.pid}-${port}`);
+
+  return {
+    transport: 'http',
+    askTimeoutMs: 1000,
+    helpTimeoutMs: 500,
+    cliDetectTimeoutMs: 100,
+    killGraceMs: 50,
+    taskTtlMs: 60_000,
+    taskPollIntervalMs: 5,
+    progressIdleHeartbeatMs: 25,
+    progressThrottleMs: 1,
+    httpHost: '127.0.0.1',
+    httpPort: port,
+    httpPath: '/mcp',
+    httpAuthToken: 'test-token',
+    httpSessionIdleMs: 60_000,
+    logPath: path.join(serviceRootDir, 'multicli.log'),
+    logLevel: 'debug',
+    stderrLogLevel: 'silent',
+    serviceRootDir,
+    serviceLogPath: path.join(serviceRootDir, 'logs', 'service.log'),
+    serviceEnvPath: path.join(serviceRootDir, 'env'),
+    serviceRuntimePath: path.join(serviceRootDir, 'runtime.json'),
+  };
+}
+
+describe.skipIf(!canBindLoopback)('httpServer', () => {
+  let server: MultiCliHttpServer | undefined;
+  let client: Client | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(detectAvailableClis).mockResolvedValue({
+      gemini: false,
+      codex: false,
+      claude: true,
+      opencode: false,
+    });
+  });
+
+  afterEach(async () => {
+    await client?.close();
+    await server?.close();
+    client = undefined;
+    server = undefined;
+  });
+
+  it('rejects unauthenticated MCP requests', async () => {
+    const config = await createHttpConfig();
+    server = await startHttpServer(config);
+
+    const response = await fetch(server.url, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2025-03-26',
+          capabilities: {},
+          clientInfo: { name: 'test-client', version: '1.0.0' },
+        },
+      }),
+    });
+
+    expect(response.status).toBe(401);
+  });
+
+  it('serves tool calls over HTTP and resolves the session working directory from roots', async () => {
+    const config = await createHttpConfig();
+    server = await startHttpServer(config);
+    vi.mocked(executeCommand).mockResolvedValue('http response');
+
+    client = new Client(
+      { name: 'http-test-client', version: '1.0.0' },
+      {
+        capabilities: {
+          roots: {},
+          tasks: {
+            list: {},
+            cancel: {},
+          },
+        },
+      },
+    );
+
+    client.setRequestHandler(ListRootsRequestSchema, async () => ({
+      roots: [{ uri: 'file:///tmp/http-root' }],
+    }));
+
+    const transport = new StreamableHTTPClientTransport(new URL(server.url), {
+      requestInit: {
+        headers: {
+          Authorization: 'Bearer test-token',
+        },
+      },
+    });
+
+    await client.connect(transport);
+
+    const result = await client.callTool(
+      {
+        name: 'Ask-Claude',
+        arguments: {
+          prompt: 'hello',
+          model: 'claude-sonnet-4-6',
+        },
+      },
+      CallToolResultSchema,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content[0].text).toContain('Claude response:\nhttp response');
+    expect(executeCommand).toHaveBeenCalledWith(
+      'claude',
+      expect.any(Array),
+      expect.objectContaining({
+        cwd: '/tmp/http-root',
+      }),
+    );
+  });
+});

--- a/tests/httpServer.test.ts
+++ b/tests/httpServer.test.ts
@@ -84,7 +84,7 @@ async function createHttpConfig(): Promise<MultiCliConfig> {
     serviceRootDir,
     serviceLogPath: path.join(serviceRootDir, 'logs', 'service.log'),
     serviceEnvPath: path.join(serviceRootDir, 'env'),
-    serviceRuntimePath: path.join(serviceRootDir, 'runtime.json'),
+    serviceManifestPath: path.join(serviceRootDir, 'manifest.json'),
   };
 }
 

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
@@ -44,5 +44,48 @@ describe('logger', () => {
     expect(parsed.meta.error.message).toBe('boom');
     expect(parsed.sessionId).toBeTruthy();
     expect(parsed.pid).toBe(process.pid);
+  });
+
+  it('serializes cyclic error causes without recursing forever', () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), 'multicli-logger-'));
+    tempDirs.push(dir);
+    const logPath = path.join(dir, 'multicli.log');
+    const logger = createLogger({
+      filePath: logPath,
+      fileLevel: 'debug',
+      stderrLevel: 'silent',
+    });
+
+    const error = new Error('cyclic');
+    error.cause = error;
+
+    logger.error('cyclic_error', { error });
+
+    const [line] = readFileSync(logPath, 'utf8').trim().split('\n');
+    const parsed = JSON.parse(line);
+    expect(parsed.meta.error.cause).toBe('[Circular]');
+  });
+
+  it('rotates logs without failing when the oldest backup already exists', () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), 'multicli-logger-'));
+    tempDirs.push(dir);
+    const logPath = path.join(dir, 'multicli.log');
+
+    writeFileSync(logPath, 'x'.repeat(11 * 1024 * 1024), 'utf8');
+    for (let index = 1; index <= 5; index += 1) {
+      writeFileSync(`${logPath}.${index}`, `backup-${index}`, 'utf8');
+    }
+
+    const logger = createLogger({
+      filePath: logPath,
+      fileLevel: 'debug',
+      stderrLevel: 'silent',
+    });
+
+    logger.info('post_rotation_entry', { ok: true });
+
+    expect(existsSync(`${logPath}.6`)).toBe(false);
+    expect(readFileSync(`${logPath}.5`, 'utf8')).toBe('backup-4');
+    expect(readFileSync(logPath, 'utf8')).toContain('post_rotation_entry');
   });
 });

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -1,0 +1,48 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { createLogger } from '../src/logger.js';
+
+describe('logger', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('writes structured JSON lines with child bindings and serialized errors', () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), 'multicli-logger-'));
+    tempDirs.push(dir);
+    const logPath = path.join(dir, 'multicli.log');
+    const logger = createLogger({
+      filePath: logPath,
+      fileLevel: 'debug',
+      stderrLevel: 'silent',
+      bindings: { component: 'testRoot' },
+    }).child({
+      component: 'childComponent',
+      requestId: 'req-123',
+    });
+
+    logger.error('structured_event', {
+      error: new Error('boom'),
+      prompt: 'FULL PROMPT BODY',
+    });
+
+    const [line] = readFileSync(logPath, 'utf8').trim().split('\n');
+    const parsed = JSON.parse(line);
+
+    expect(parsed.event).toBe('structured_event');
+    expect(parsed.component).toBe('childComponent');
+    expect(parsed.requestId).toBe('req-123');
+    expect(parsed.meta.prompt).toBe('FULL PROMPT BODY');
+    expect(parsed.meta.error.message).toBe('boom');
+    expect(parsed.sessionId).toBeTruthy();
+    expect(parsed.pid).toBe(process.pid);
+  });
+});

--- a/tests/serverApp.test.ts
+++ b/tests/serverApp.test.ts
@@ -2,6 +2,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { CallToolResultSchema } from '@modelcontextprotocol/sdk/types.js';
+import { readFileSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 
 vi.mock('../src/utils/cliDetector.js', () => ({
   detectAvailableClis: vi.fn(),
@@ -20,6 +23,7 @@ import { executeCommand, CommandExecutionError } from '../src/utils/commandExecu
 import { createServerApp } from '../src/serverApp.js';
 import type { MultiCliServerApp } from '../src/serverApp.js';
 import type { MultiCliConfig } from '../src/config.js';
+import type { CreateServerAppOptions } from '../src/serverApp.js';
 
 const TEST_CONFIG: MultiCliConfig = {
   askTimeoutMs: 1000,
@@ -30,10 +34,12 @@ const TEST_CONFIG: MultiCliConfig = {
   taskPollIntervalMs: 5,
   progressIdleHeartbeatMs: 25,
   progressThrottleMs: 1,
-  logLevel: 'error',
+  logPath: path.join(os.tmpdir(), `multicli-server-app-${process.pid}.log`),
+  logLevel: 'debug',
+  stderrLogLevel: 'silent',
 };
 
-async function createConnectedPair() {
+async function createConnectedPair(options?: CreateServerAppOptions) {
   vi.mocked(detectAvailableClis).mockResolvedValue({
     gemini: false,
     codex: false,
@@ -41,7 +47,7 @@ async function createConnectedPair() {
     opencode: false,
   });
 
-  const app = await createServerApp(TEST_CONFIG);
+  const app = await createServerApp(TEST_CONFIG, undefined, options);
   const client = new Client(
     { name: 'integration-test-client', version: '1.0.0' },
     {
@@ -69,6 +75,7 @@ describe('serverApp', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    rmSync(TEST_CONFIG.logPath, { force: true });
   });
 
   afterEach(async () => {
@@ -140,6 +147,54 @@ describe('serverApp', () => {
         String(progress.message).includes('second line'),
       ),
     ).toBe(true);
+  });
+
+  it('drains in-flight progress notifications before returning the tool result', async () => {
+    ({ app, client } = await createConnectedPair());
+    vi.mocked(executeCommand).mockImplementation(async (_command, _args, options) => {
+      options?.onProgress?.('first line\nsecond line');
+      return 'done';
+    });
+
+    const originalNotification = app.server.notification.bind(app.server);
+    const clientError = vi.fn();
+    const progressMessages: string[] = [];
+
+    client.onerror = clientError;
+    app.server.notification = vi.fn(async (...args: Parameters<typeof app.server.notification>) => {
+      const [notification, options] = args;
+      if (notification.method === 'notifications/progress') {
+        const message = String(
+          (notification.params as { message?: string } | undefined)?.message ?? '',
+        );
+        progressMessages.push(message);
+
+        if (message.includes('second line')) {
+          await new Promise(resolve => setTimeout(resolve, 25));
+        }
+      }
+
+      return originalNotification(notification, options);
+    });
+
+    const result = await client.callTool(
+      {
+        name: 'Ask-Claude',
+        arguments: {
+          prompt: 'hello',
+          model: 'claude-sonnet-4-6',
+        },
+      },
+      CallToolResultSchema,
+      { onprogress: vi.fn() },
+    );
+
+    expect(result.isError).toBe(false);
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    expect(progressMessages.some(message => message.includes('second line'))).toBe(true);
+    expect(progressMessages).toContain('Completed Ask-Claude');
+    expect(clientError).not.toHaveBeenCalled();
   });
 
   it('propagates client cancellation to the running sync subprocess', async () => {
@@ -251,5 +306,57 @@ describe('serverApp', () => {
     expect(aborted).toBe(true);
 
     await iterator.return?.();
+  });
+
+  it('logs full prompt bodies for tool requests', async () => {
+    ({ app, client } = await createConnectedPair());
+    vi.mocked(executeCommand).mockResolvedValue('logged response');
+
+    await client.callTool(
+      {
+        name: 'Ask-Claude',
+        arguments: {
+          prompt: 'TRACE_THIS_FULL_PROMPT_BODY',
+          model: 'claude-sonnet-4-6',
+        },
+      },
+      CallToolResultSchema,
+    );
+
+    const logContents = readFileSync(TEST_CONFIG.logPath, 'utf8');
+    expect(logContents).toContain('TRACE_THIS_FULL_PROMPT_BODY');
+    expect(logContents).toContain('tool_request_started');
+  });
+
+  it('resolves session working directory before tool execution', async () => {
+    ({ app, client } = await createConnectedPair({
+      sessionContext: {
+        transport: 'http',
+        resolveWorkingDirectory: vi.fn().mockResolvedValue({
+          cwd: '/tmp/http-project',
+          projectRoots: [{ uri: 'file:///tmp/http-project' }],
+        }),
+      },
+    }));
+    vi.mocked(executeCommand).mockResolvedValue('resolved response');
+
+    await client.callTool(
+      {
+        name: 'Ask-Claude',
+        arguments: {
+          prompt: 'hello',
+          model: 'claude-sonnet-4-6',
+        },
+      },
+      CallToolResultSchema,
+    );
+
+    expect(executeCommand).toHaveBeenCalledWith(
+      'claude',
+      expect.any(Array),
+      expect.objectContaining({
+        cwd: '/tmp/http-project',
+      }),
+    );
   });
 });

--- a/tests/service.test.ts
+++ b/tests/service.test.ts
@@ -1,0 +1,172 @@
+import os from 'node:os';
+import path from 'node:path';
+import { rmSync, writeFileSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+import type { MultiCliConfig } from '../src/config.js';
+import { getServiceKind, getServicePaths } from '../src/service/paths.js';
+import { loadServiceEnvironment } from '../src/service/bootstrap.js';
+import { isMatchingClaudeConfigOutput } from '../src/service/manager.js';
+import {
+  buildServiceEnvFileContents,
+  createServiceManifest,
+} from '../src/service/runtime.js';
+import {
+  renderLaunchAgent,
+  renderPosixLauncher,
+  renderSystemdUnit,
+  renderWindowsLauncher,
+  renderWindowsTaskXml,
+} from '../src/service/renderers.js';
+
+function createConfig(overrides: Partial<MultiCliConfig> = {}): MultiCliConfig {
+  const serviceRootDir = path.join(os.tmpdir(), 'multicli-service-test');
+
+  return {
+    transport: 'http',
+    askTimeoutMs: 1_000,
+    helpTimeoutMs: 500,
+    cliDetectTimeoutMs: 100,
+    killGraceMs: 50,
+    taskTtlMs: 60_000,
+    taskPollIntervalMs: 5,
+    progressIdleHeartbeatMs: 25,
+    progressThrottleMs: 1,
+    httpHost: '127.0.0.1',
+    httpPort: 37420,
+    httpPath: '/mcp',
+    httpAuthToken: 'token',
+    httpSessionIdleMs: 60_000,
+    logPath: path.join(serviceRootDir, 'multicli.log'),
+    logLevel: 'debug',
+    stderrLogLevel: 'silent',
+    serviceRootDir,
+    serviceLogPath: path.join(serviceRootDir, 'logs', 'service.log'),
+    serviceEnvPath: path.join(serviceRootDir, 'env'),
+    serviceRuntimePath: path.join(serviceRootDir, 'runtime.json'),
+    ...overrides,
+  };
+}
+
+describe('service paths', () => {
+  it('selects the expected service kind for each platform', () => {
+    expect(getServiceKind('darwin')).toBe('launchd');
+    expect(getServiceKind('linux')).toBe('systemd-user');
+    expect(getServiceKind('win32')).toBe('windows-task');
+  });
+
+  it('renders platform-specific service definition paths', () => {
+    const config = createConfig();
+
+    expect(getServicePaths(config, 'darwin').serviceDefinition).toContain('LaunchAgents');
+    expect(getServicePaths(config, 'linux').serviceDefinition).toContain('systemd/user');
+    expect(getServicePaths(config, 'win32').serviceDefinition).toContain('task.xml');
+  });
+
+  it('uses a recognizable launcher filename on macOS', () => {
+    const config = createConfig();
+
+    expect(path.basename(getServicePaths(config, 'darwin').launcher)).toBe('Multi-CLI.sh');
+    expect(path.basename(getServicePaths(config, 'linux').launcher)).toBe('launcher.sh');
+  });
+});
+
+describe('service runtime', () => {
+  it('builds a manifest with the expected transport metadata', () => {
+    const manifest = createServiceManifest(createConfig(), 'token-value', 'darwin');
+
+    expect(manifest.transport.url).toBe('http://127.0.0.1:37420/mcp');
+    expect(manifest.transport.healthUrl).toBe('http://127.0.0.1:37420/health');
+    expect(manifest.transport.token).toBe('token-value');
+    expect(manifest.runtime.bootstrapPath).toContain('bootstrap.');
+  });
+
+  it('renders a JSON env file with PATH and managed Multi-CLI variables', () => {
+    const manifest = createServiceManifest(createConfig(), 'token-value', 'darwin');
+    const contents = buildServiceEnvFileContents(manifest, {
+      PATH: '/usr/local/bin:/usr/bin',
+      OPENAI_API_KEY: 'secret',
+    });
+
+    const parsed = JSON.parse(contents) as Record<string, string>;
+
+    expect(parsed.PATH).toBe('/usr/local/bin:/usr/bin');
+    expect(parsed.OPENAI_API_KEY).toBe('secret');
+    expect(parsed.MULTICLI_TRANSPORT).toBe('http');
+    expect(parsed.MULTICLI_HTTP_AUTH_TOKEN).toBe('token-value');
+    expect(parsed.MULTICLI_LOG_PATH).toBe(manifest.paths.logFile);
+  });
+
+  it('loads the JSON env file into process environment entries', () => {
+    const envFile = path.join(os.tmpdir(), `multicli-service-env-${process.pid}.json`);
+    writeFileSync(envFile, JSON.stringify({ PATH: '/tmp/bin', MULTICLI_HTTP_AUTH_TOKEN: 'token-value' }), 'utf8');
+
+    try {
+      const env = loadServiceEnvironment(envFile, {});
+      expect(env.PATH).toBe('/tmp/bin');
+      expect(env.MULTICLI_HTTP_AUTH_TOKEN).toBe('token-value');
+    } finally {
+      rmSync(envFile, { force: true });
+    }
+  });
+});
+
+describe('service renderers', () => {
+  it('renders a POSIX launcher that boots the service bootstrap', () => {
+    const manifest = createServiceManifest(createConfig(), 'token-value', 'darwin');
+    const script = renderPosixLauncher(manifest);
+
+    expect(script).toContain(manifest.paths.envFile);
+    expect(script).toContain(manifest.runtime.nodePath);
+    expect(script).toContain(manifest.runtime.bootstrapPath);
+    expect(script).toContain('serve-http');
+  });
+
+  it('renders a Windows launcher that boots the service bootstrap', () => {
+    const manifest = createServiceManifest(createConfig(), 'token-value', 'win32');
+    const script = renderWindowsLauncher(manifest);
+
+    expect(script).toContain(manifest.paths.envFile);
+    expect(script).toContain(manifest.runtime.nodePath);
+    expect(script).toContain(manifest.runtime.bootstrapPath);
+    expect(script).toContain('serve-http');
+  });
+
+  it('renders native service definitions for each platform', () => {
+    const manifest = createServiceManifest(createConfig(), 'token-value', 'darwin');
+    expect(renderLaunchAgent(manifest)).toContain('<key>Label</key>');
+    expect(renderSystemdUnit(createServiceManifest(createConfig(), 'token-value', 'linux')))
+      .toContain('ExecStart=');
+    expect(renderWindowsTaskXml(createServiceManifest(createConfig(), 'token-value', 'win32')))
+      .toContain('<LogonTrigger>');
+  });
+});
+
+describe('service manager', () => {
+  it('matches Claude MCP output only for the managed HTTP config', () => {
+    const manifest = createServiceManifest(createConfig(), 'token-value', 'darwin');
+
+    const matchingOutput = [
+      'Multi-CLI:',
+      '  Scope: User config (available in all your projects)',
+      '  Status: ✓ Connected',
+      '  Type: http',
+      `  URL: ${manifest.transport.url}`,
+      '  Headers:',
+      `    Authorization: Bearer ${manifest.transport.token}`,
+    ].join('\n');
+
+    const stdioOutput = [
+      'Multi-CLI:',
+      '  Scope: User config (available in all your projects)',
+      '  Status: ✓ Connected',
+      '  Type: stdio',
+      '  Command: node',
+      '  Args: /Users/arlogilbert/Repos/multicli/dist/index.js',
+    ].join('\n');
+
+    expect(isMatchingClaudeConfigOutput(matchingOutput, manifest)).toBe(true);
+    expect(isMatchingClaudeConfigOutput(stdioOutput, manifest)).toBe(false);
+  });
+});

--- a/tests/service.test.ts
+++ b/tests/service.test.ts
@@ -44,7 +44,7 @@ function createConfig(overrides: Partial<MultiCliConfig> = {}): MultiCliConfig {
     serviceRootDir,
     serviceLogPath: path.join(serviceRootDir, 'logs', 'service.log'),
     serviceEnvPath: path.join(serviceRootDir, 'env'),
-    serviceRuntimePath: path.join(serviceRootDir, 'runtime.json'),
+    serviceManifestPath: path.join(serviceRootDir, 'manifest.json'),
     ...overrides,
   };
 }
@@ -96,6 +96,8 @@ describe('service runtime', () => {
     expect(parsed.MULTICLI_TRANSPORT).toBe('http');
     expect(parsed.MULTICLI_HTTP_AUTH_TOKEN).toBe('token-value');
     expect(parsed.MULTICLI_LOG_PATH).toBe(manifest.paths.logFile);
+    expect(parsed.MULTICLI_SERVICE_MANIFEST_PATH).toBe(manifest.paths.manifest);
+    expect(parsed.MULTICLI_SERVICE_RUNTIME_PATH).toBeUndefined();
   });
 
   it('loads the JSON env file into process environment entries', () => {

--- a/tests/utils/commandExecutor.test.ts
+++ b/tests/utils/commandExecutor.test.ts
@@ -224,7 +224,7 @@ describe('commandExecutor', () => {
     }
   });
 
-  it('logs subprocess lifecycle events and full command args', async () => {
+  it('logs subprocess lifecycle events while redacting sensitive command data', async () => {
     const dir = mkdtempSync(path.join(os.tmpdir(), 'multicli-command-'));
     try {
       const logPath = path.join(dir, 'multicli.log');
@@ -237,10 +237,15 @@ describe('commandExecutor', () => {
       const mock = createMockProcess();
       vi.mocked(spawn).mockReturnValue(mock.proc as any);
 
-      const promise = executeCommand('claude', ['--print', 'FULL PROMPT BODY'], {
+      const promise = executeCommand('claude', [
+        '--print',
+        'FULL PROMPT BODY',
+        '--header',
+        'Authorization: Bearer SUPERSECRET',
+      ], {
         logger,
       });
-      mock.emitStdout('tool output');
+      mock.emitStdout('tool output\nAuthorization: Bearer LEAKED');
       mock.emitClose(0);
 
       await promise;
@@ -249,7 +254,10 @@ describe('commandExecutor', () => {
       expect(logContents).toContain('command_spawn_requested');
       expect(logContents).toContain('command_stdout_chunk');
       expect(logContents).toContain('FULL PROMPT BODY');
+      expect(logContents).toContain('Authorization: Bearer [Redacted]');
       expect(logContents).toContain('tool output');
+      expect(logContents).not.toContain('SUPERSECRET');
+      expect(logContents).not.toContain('LEAKED');
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/tests/utils/commandExecutor.test.ts
+++ b/tests/utils/commandExecutor.test.ts
@@ -1,12 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { EventEmitter } from 'events';
 import { spawn } from 'child_process';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 
 vi.mock('child_process', () => ({
   spawn: vi.fn(),
 }));
 
 import { executeCommand, sanitizeArgForCmd } from '../../src/utils/commandExecutor.js';
+import { createLogger } from '../../src/logger.js';
 
 function createMockProcess() {
   const proc = {
@@ -218,6 +222,66 @@ describe('commandExecutor', () => {
     } finally {
       processKill.mockRestore();
     }
+  });
+
+  it('logs subprocess lifecycle events and full command args', async () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), 'multicli-command-'));
+    try {
+      const logPath = path.join(dir, 'multicli.log');
+      const logger = createLogger({
+        filePath: logPath,
+        fileLevel: 'debug',
+        stderrLevel: 'silent',
+        bindings: { component: 'testCommand' },
+      });
+      const mock = createMockProcess();
+      vi.mocked(spawn).mockReturnValue(mock.proc as any);
+
+      const promise = executeCommand('claude', ['--print', 'FULL PROMPT BODY'], {
+        logger,
+      });
+      mock.emitStdout('tool output');
+      mock.emitClose(0);
+
+      await promise;
+
+      const logContents = readFileSync(logPath, 'utf8');
+      expect(logContents).toContain('command_spawn_requested');
+      expect(logContents).toContain('command_stdout_chunk');
+      expect(logContents).toContain('FULL PROMPT BODY');
+      expect(logContents).toContain('tool output');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('passes cwd and env overrides through to spawn', async () => {
+    const mock = createMockProcess();
+    vi.mocked(spawn).mockReturnValue(mock.proc as any);
+
+    const promise = executeCommand('claude', ['--help'], {
+      cwd: '/tmp/project-root',
+      env: {
+        PATH: '/custom/bin',
+        MULTICLI_SERVICE: '1',
+      },
+    });
+    mock.emitStdout('help output');
+    mock.emitClose(0);
+
+    await promise;
+
+    expect(spawn).toHaveBeenCalledWith(
+      'claude',
+      ['--help'],
+      expect.objectContaining({
+        cwd: '/tmp/project-root',
+        env: {
+          PATH: '/custom/bin',
+          MULTICLI_SERVICE: '1',
+        },
+      }),
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- add highly verbose structured JSONL logging to a single on-disk destination, including full prompt capture, to trace MCP disconnects and exits
- add a localhost-only Streamable HTTP transport plus managed `service install`, `doctor`, `logs`, `refresh`, and `uninstall` flows for macOS, Linux, and Windows
- preserve stdio support while fixing service log routing, Claude-config uninstall safety, HTTP working-directory resolution, and macOS launcher naming (`Multi-CLI.sh`)

## Validation
- `npm run lint`
- `npm test` (`21` files, `311` tests)
- `npm run build`
- local macOS lifecycle validation: `node dist/index.js service install`, `service doctor`, `service refresh`, `service logs`, `service uninstall`
- repeated Claude-over-HTTP smoke against the managed localhost service

## Accepted Gaps
- install rollback and full generated-artifact cleanup is still open
- live Linux and Windows service lifecycle validation has not been executed yet

## QA Notes
- Prior Claude and Gemini QA findings from this branch were addressed during implementation
- A fresh Gemini re-review was requested before release, but tenant policy blocked sending the repo/diff to the external Gemini service; no new Gemini findings were returned

## Authors
Claude, Codex, and Gemini
