### PR TITLE
[codex] fix Codex model catalog extraction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,12 @@ Multi-CLI — an MCP (Model Context Protocol) server that lets AI clients (Claud
 5. **Document Results**: Add review section to `tasks/todo.md`
 6. **Capture Lessons**: Record in `tasks/lessons.md` (create if needed)
 
+## GitHub CLI Auth
+
+- On this machine, `gh` may be authenticated via the macOS keyring but appear unauthenticated inside Codex's default sandbox because the keyring token is not visible there.
+- If `gh auth status` fails in Codex but the user says `gh` is authed, rerun the same `gh` command with escalation before concluding auth is broken.
+- Prefer escalated `gh` for GitHub API operations that require keyring credentials, including PR creation, PR checks, and workflow log inspection.
+
 ### 8. Releases
 - The release workflow (`release.yml`) uses a **bump PR pattern** triggered on every push to `main` and on `workflow_dispatch`.
 - If the current `package.json` version is already published on npm, the workflow creates an automated `chore/version-bump` PR that increments the patch version and enables auto-merge.

--- a/scripts/extract-codex.sh
+++ b/scripts/extract-codex.sh
@@ -4,7 +4,10 @@
 # Use a unique temporary directory
 TMP_DIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'codex-extract')
 REPO_URL="${CODEX_REPO_URL:-https://github.com/openai/codex}"
-MODELS_FILE="codex-rs/core/models.json"
+MODELS_FILES=(
+    "codex-rs/models-manager/models.json"
+    "codex-rs/core/models.json"
+)
 
 # Function to clean up on exit
 cleanup() {
@@ -20,18 +23,26 @@ fi
 
 cd "$TMP_DIR" || { echo "[]"; exit 0; }
 
-# 2. Attempt to checkout the models file from main
-if ! git checkout main -- "$MODELS_FILE" > /dev/null 2>&1; then
-    # Fallback to master if main failed
-    if ! git checkout master -- "$MODELS_FILE" > /dev/null 2>&1; then
-        echo "[]"
-        exit 0
-    fi
+# 2. Attempt to checkout the models file from main, then master.
+# Codex moved the bundled model metadata from core/ to models-manager/.
+MODELS_FILE=""
+for branch in main master; do
+    for candidate in "${MODELS_FILES[@]}"; do
+        if git checkout "$branch" -- "$candidate" > /dev/null 2>&1; then
+            MODELS_FILE="$candidate"
+            break 2
+        fi
+    done
+done
+
+if [ -z "$MODELS_FILE" ]; then
+    echo "[]"
+    exit 0
 fi
 
 # 3. Extract slugs using jq and output as a JSON array to stdout
 if [ -f "$MODELS_FILE" ]; then
-    RESULT=$(jq -c '[.models[].slug | select(contains("oss") | not)] | unique' "$MODELS_FILE")
+    RESULT=$(jq -c '[.models[].slug | select(startswith("gpt-")) | select(contains("oss") | not)] | unique' "$MODELS_FILE")
 else
     RESULT="[]"
 fi

--- a/tests/extractCodex.test.ts
+++ b/tests/extractCodex.test.ts
@@ -1,0 +1,71 @@
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const scriptPath = resolve(process.cwd(), 'scripts', 'extract-codex.sh');
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function makeTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'multicli-codex-extract-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function writeModelsRepo(modelPath: string, slugs: string[]): string {
+  const repoDir = makeTempDir();
+  execFileSync('git', ['init', '-b', 'main'], { cwd: repoDir, stdio: 'pipe' });
+  execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: repoDir });
+  execFileSync('git', ['config', 'user.name', 'Test User'], { cwd: repoDir });
+  execFileSync('git', ['config', 'commit.gpgsign', 'false'], { cwd: repoDir });
+
+  const fullPath = join(repoDir, modelPath);
+  mkdirSync(resolve(fullPath, '..'), { recursive: true });
+  writeFileSync(
+    fullPath,
+    JSON.stringify({ models: slugs.map((slug) => ({ slug })) }, null, 2),
+    'utf-8',
+  );
+
+  execFileSync('git', ['add', modelPath], { cwd: repoDir });
+  execFileSync('git', ['commit', '-m', 'add models'], { cwd: repoDir, stdio: 'pipe' });
+  return repoDir;
+}
+
+function extract(repoDir: string): string[] {
+  const stdout = execFileSync('bash', [scriptPath], {
+    encoding: 'utf-8',
+    env: { ...process.env, CODEX_REPO_URL: repoDir },
+  });
+  return JSON.parse(stdout) as string[];
+}
+
+describe('extract-codex.sh', () => {
+  it('reads the current Codex models-manager catalog path', () => {
+    const repoDir = writeModelsRepo('codex-rs/models-manager/models.json', [
+      'gpt-5.5',
+      'gpt-5.4-mini',
+      'codex-auto-review',
+      'gpt-oss-20b',
+    ]);
+
+    expect(extract(repoDir)).toEqual(['gpt-5.4-mini', 'gpt-5.5']);
+  });
+
+  it('falls back to the legacy core catalog path', () => {
+    const repoDir = writeModelsRepo('codex-rs/core/models.json', [
+      'gpt-5.4',
+      'gpt-5.3-codex',
+    ]);
+
+    expect(extract(repoDir)).toEqual(['gpt-5.3-codex', 'gpt-5.4']);
+  });
+});


### PR DESCRIPTION
## Summary

- Update the Codex model extractor to read the current upstream metadata path at `codex-rs/models-manager/models.json`.
- Keep the legacy `codex-rs/core/models.json` path as a fallback for older Codex revisions.
- Filter extractor output to non-OSS `gpt-*` model IDs and add regression coverage for the current and legacy paths.

## Root Cause

The nightly catalog refresh was still checking out `codex-rs/core/models.json`, but upstream `openai/codex` moved bundled model metadata to `codex-rs/models-manager/models.json`. The current upstream metadata includes `gpt-5.5`, so the old path prevented the refresh from discovering it.

## Validation

- `npm test -- tests/extractCodex.test.ts`
- `npm test`
- `npm run lint`
- `npm run build`
- `bash scripts/extract-codex.sh` against upstream returned `gpt-5.5`

Authored-by: Claude, Codex, and Gemini