### PR TITLE
feat: add Cursor Agent CLI support

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,6 +15,7 @@ export const STATUS_MESSAGES = {
   CODEX_RESPONSE: "Codex response:",
   CLAUDE_RESPONSE: "Claude response:",
   OPENCODE_RESPONSE: "OpenCode response:",
+  CURSOR_RESPONSE: "Cursor response:",
   // Timeout prevention messages
   PROCESSING_START: "🔍 Starting analysis (may take 5-15 minutes for large codebases)",
   PROCESSING_CONTINUE: "⏳ Still processing...",
@@ -56,6 +57,7 @@ export const CLI = {
     CODEX: "codex",
     CLAUDE: "claude",
     OPENCODE: "opencode",
+    CURSOR: "cursor-agent",
     ECHO: "echo",
   },
   // Gemini command flags
@@ -100,6 +102,17 @@ export const CLI = {
   OPENCODE_SUBCOMMANDS: {
     RUN: "run",
     MODELS: "models",
+  },
+  // Cursor Agent CLI flags
+  CURSOR_FLAGS: {
+    PRINT: "--print",
+    OUTPUT_FORMAT: "--output-format",
+    MODEL: "--model",
+    LIST_MODELS: "--list-models",
+    FORCE: "--force",
+    TRUST: "--trust",
+    WORKSPACE: "--workspace",
+    HELP: "--help",
   },
   // Default values
   DEFAULTS: {

--- a/src/tools/ask-cursor.tool.ts
+++ b/src/tools/ask-cursor.tool.ts
@@ -1,0 +1,42 @@
+import { z } from 'zod';
+import { UnifiedTool } from './registry.js';
+import { executeCursorCLI } from '../utils/cursorExecutor.js';
+import { ERROR_MESSAGES, STATUS_MESSAGES } from '../constants.js';
+
+const askCursorArgsSchema = z.object({
+  prompt: z.string().min(1).describe("The question or task for Cursor Agent CLI. REQUIRED — MUST be a non-empty string. Describe what you need clearly."),
+  model: z.string().min(1).describe("REQUIRED — you MUST first call List-Cursor-Models to see available models and select one."),
+  force: z.boolean().optional().describe("Optional. Bypass prompts to run forcefully."),
+  trust: z.boolean().optional().describe("Optional. Automatically trust and execute suggested commands."),
+  workspace: z.string().optional().describe("Optional. Path to the workspace to operate in."),
+});
+
+export const askCursorTool: UnifiedTool = {
+  name: "Ask-Cursor",
+  description: "Ask Cursor Agent CLI a question or give it a task. You MUST call List-Cursor-Models first to select an appropriate model.",
+  zodSchema: askCursorArgsSchema,
+  prompt: {
+    description: "Execute 'cursor-agent --print <prompt>' to get Cursor Agent's response.",
+  },
+  category: 'cursor',
+  execution: { taskSupport: 'optional' },
+  timeoutClass: 'ask',
+  execute: async (args, context) => {
+    const { prompt, model, force, trust, workspace } = args;
+
+    if (!prompt || typeof prompt !== 'string' || !prompt.trim()) {
+      throw new Error(ERROR_MESSAGES.NO_PROMPT_PROVIDED);
+    }
+
+    const result = await executeCursorCLI(
+      prompt,
+      model as string,
+      force as boolean | undefined,
+      trust as boolean | undefined,
+      workspace as string | undefined,
+      context
+    );
+
+    return `${STATUS_MESSAGES.CURSOR_RESPONSE}\n${result}`;
+  }
+};

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -2,13 +2,14 @@
 import { toolRegistry } from './registry.js';
 import { askGeminiTool } from './ask-gemini.tool.js';
 import {
-  geminiHelpTool, codexHelpTool, claudeHelpTool, opencodeHelpTool,
-  geminiListModelsTool, codexListModelsTool, claudeListModelsTool, opencodeListModelsTool,
+  geminiHelpTool, codexHelpTool, claudeHelpTool, opencodeHelpTool, cursorHelpTool,
+  geminiListModelsTool, codexListModelsTool, claudeListModelsTool, opencodeListModelsTool, cursorListModelsTool,
 } from './simple-tools.js';
 import { fetchChunkTool } from './fetch-chunk.tool.js';
 import { askCodexTool } from './ask-codex.tool.js';
 import { askClaudeTool } from './ask-claude.tool.js';
 import { askOpencodeTool } from './ask-opencode.tool.js';
+import { askCursorTool } from './ask-cursor.tool.js';
 import { detectAvailableClis, CliAvailability } from '../utils/cliDetector.js';
 import { MultiCliConfig } from '../config.js';
 import type { Logger } from '../logger.js';
@@ -56,6 +57,14 @@ export async function initTools(
       opencodeListModelsTool, // List-OpenCode-Models
       askOpencodeTool,        // Ask-OpenCode
       opencodeHelpTool,       // OpenCode-Help
+    );
+  }
+
+  if (availability.cursor) {
+    toolRegistry.push(
+      cursorListModelsTool,   // List-Cursor-Models
+      askCursorTool,          // Ask-Cursor
+      cursorHelpTool,         // Cursor-Help
     );
   }
 

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -19,7 +19,7 @@ export interface UnifiedTool {
   };
   
   execute: (args: ToolArguments, context?: ToolExecutionContext) => Promise<string>;
-  category?: 'gemini' | 'codex' | 'claude' | 'opencode' | 'utility';
+  category?: 'gemini' | 'codex' | 'claude' | 'opencode' | 'cursor' | 'utility';
   execution?: Tool['execution'];
   timeoutClass?: ToolTimeoutClass;
 }

--- a/src/tools/simple-tools.ts
+++ b/src/tools/simple-tools.ts
@@ -3,6 +3,7 @@ import { UnifiedTool } from './registry.js';
 import { executeCommand } from '../utils/commandExecutor.js';
 import { formatCatalog } from '../modelCatalog.js';
 import { getOpencodeClassifiedCatalog } from '../utils/opencodeCatalog.js';
+import { CLI } from '../constants.js';
 
 const helpArgsSchema = z.object({});
 
@@ -106,4 +107,29 @@ export const opencodeListModelsTool: UnifiedTool = {
   execute: async () => {
     return getOpencodeClassifiedCatalog();
   }
+};
+
+export const cursorHelpTool: UnifiedTool = {
+  name: "Cursor-Help",
+  description: "Receive help information from the Cursor Agent CLI",
+  zodSchema: helpArgsSchema,
+  prompt: {
+    description: "Receive help information from the Cursor Agent CLI",
+  },
+  category: 'cursor',
+  timeoutClass: 'help',
+  execute: async (_args, context) => executeCommand("cursor-agent", ["--help"], context),
+};
+
+export const cursorListModelsTool: UnifiedTool = {
+  name: "List-Cursor-Models",
+  description: "List available Cursor Agent CLI models (cursor-agent --list-models). You MUST call this before Ask-Cursor to choose a valid model.",
+  zodSchema: noArgsSchema,
+  prompt: {
+    description: "List available Cursor models from the Agent CLI",
+  },
+  category: 'cursor',
+  timeoutClass: 'help',
+  execute: async (_args, context) =>
+    executeCommand(CLI.COMMANDS.CURSOR, [CLI.CURSOR_FLAGS.LIST_MODELS], context),
 };

--- a/src/utils/cliDetector.ts
+++ b/src/utils/cliDetector.ts
@@ -81,11 +81,12 @@ export interface CliAvailability {
   codex: boolean;
   claude: boolean;
   opencode: boolean;
+  cursor: boolean;
 }
 
 /**
- * Detect which of the four supported CLIs are available on the system.
- * Runs all four checks in parallel for speed.
+ * Detect which of the supported CLIs are available on the system.
+ * Runs all checks in parallel for speed.
  */
 export async function detectAvailableClis(
   timeoutMs?: number,
@@ -95,18 +96,19 @@ export async function detectAvailableClis(
     logger?.info('cli_detection_skipped', {
       reason: 'QA_NO_CLIS=true',
     });
-    return { gemini: false, codex: false, claude: false, opencode: false };
+    return { gemini: false, codex: false, claude: false, opencode: false, cursor: false };
   }
 
   logger?.info('cli_detection_started', { timeoutMs });
-  const [gemini, codex, claude, opencode] = await Promise.all([
+  const [gemini, codex, claude, opencode, cursor] = await Promise.all([
     commandExists(CLI.COMMANDS.GEMINI, timeoutMs, logger),
     commandExists(CLI.COMMANDS.CODEX, timeoutMs, logger),
     commandExists(CLI.COMMANDS.CLAUDE, timeoutMs, logger),
     commandExists(CLI.COMMANDS.OPENCODE, timeoutMs, logger),
+    commandExists(CLI.COMMANDS.CURSOR, timeoutMs, logger),
   ]);
 
-  const availability: CliAvailability = { gemini, codex, claude, opencode };
+  const availability: CliAvailability = { gemini, codex, claude, opencode, cursor };
   logger?.info('cli_detection_finished', { availability });
 
   return availability;

--- a/src/utils/cursorExecutor.ts
+++ b/src/utils/cursorExecutor.ts
@@ -1,0 +1,34 @@
+import { executeCommand } from './commandExecutor.js';
+import { CLI } from '../constants.js';
+import { ToolExecutionContext } from '../execution.js';
+
+export async function executeCursorCLI(
+  prompt: string,
+  model: string,
+  force?: boolean,
+  trust?: boolean,
+  workspace?: string,
+  context?: ToolExecutionContext,
+): Promise<string> {
+  const args: string[] = [
+    CLI.CURSOR_FLAGS.PRINT,
+    CLI.CURSOR_FLAGS.OUTPUT_FORMAT, "text",
+    CLI.CURSOR_FLAGS.MODEL, model,
+  ];
+
+  if (force) {
+    args.push(CLI.CURSOR_FLAGS.FORCE);
+  }
+
+  if (trust) {
+    args.push(CLI.CURSOR_FLAGS.TRUST);
+  }
+
+  if (workspace) {
+    args.push(CLI.CURSOR_FLAGS.WORKSPACE, workspace);
+  }
+
+  args.push(prompt);
+
+  return executeCommand(CLI.COMMANDS.CURSOR, args, context);
+}

--- a/tests/tools/initTools.test.ts
+++ b/tests/tools/initTools.test.ts
@@ -24,7 +24,7 @@ describe('initTools', () => {
 
   it('registers gemini tools when gemini available', async () => {
     vi.mocked(detectAvailableClis).mockResolvedValue({
-      gemini: true, codex: false, claude: false, opencode: false,
+      gemini: true, codex: false, claude: false, opencode: false, cursor: false,
     });
 
     await initTools();
@@ -38,11 +38,12 @@ describe('initTools', () => {
     expect(names).not.toContain('Ask-Codex');
     expect(names).not.toContain('Ask-Claude');
     expect(names).not.toContain('Ask-OpenCode');
+    expect(names).not.toContain('Ask-Cursor');
   });
 
   it('registers codex tools when codex available', async () => {
     vi.mocked(detectAvailableClis).mockResolvedValue({
-      gemini: false, codex: true, claude: false, opencode: false,
+      gemini: false, codex: true, claude: false, opencode: false, cursor: false,
     });
 
     await initTools();
@@ -54,11 +55,12 @@ describe('initTools', () => {
     expect(names).not.toContain('Ask-Gemini');
     expect(names).not.toContain('Ask-Claude');
     expect(names).not.toContain('Ask-OpenCode');
+    expect(names).not.toContain('Ask-Cursor');
   });
 
   it('registers claude tools when claude available', async () => {
     vi.mocked(detectAvailableClis).mockResolvedValue({
-      gemini: false, codex: false, claude: true, opencode: false,
+      gemini: false, codex: false, claude: true, opencode: false, cursor: false,
     });
 
     await initTools();
@@ -70,11 +72,12 @@ describe('initTools', () => {
     expect(names).not.toContain('Ask-Gemini');
     expect(names).not.toContain('Ask-Codex');
     expect(names).not.toContain('Ask-OpenCode');
+    expect(names).not.toContain('Ask-Cursor');
   });
 
   it('registers opencode tools when opencode available', async () => {
     vi.mocked(detectAvailableClis).mockResolvedValue({
-      gemini: false, codex: false, claude: false, opencode: true,
+      gemini: false, codex: false, claude: false, opencode: true, cursor: false,
     });
 
     await initTools();
@@ -86,11 +89,29 @@ describe('initTools', () => {
     expect(names).not.toContain('Ask-Gemini');
     expect(names).not.toContain('Ask-Codex');
     expect(names).not.toContain('Ask-Claude');
+    expect(names).not.toContain('Ask-Cursor');
+  });
+
+  it('registers cursor tools when cursor available', async () => {
+    vi.mocked(detectAvailableClis).mockResolvedValue({
+      gemini: false, codex: false, claude: false, opencode: false, cursor: true,
+    });
+
+    await initTools();
+
+    const names = toolRegistry.map(t => t.name);
+    expect(names).toContain('List-Cursor-Models');
+    expect(names).toContain('Ask-Cursor');
+    expect(names).toContain('Cursor-Help');
+    expect(names).not.toContain('Ask-Gemini');
+    expect(names).not.toContain('Ask-Codex');
+    expect(names).not.toContain('Ask-Claude');
+    expect(names).not.toContain('Ask-OpenCode');
   });
 
   it('registers tools for multiple available CLIs', async () => {
     vi.mocked(detectAvailableClis).mockResolvedValue({
-      gemini: true, codex: true, claude: false, opencode: false,
+      gemini: true, codex: true, claude: false, opencode: false, cursor: false,
     });
 
     await initTools();
@@ -100,11 +121,12 @@ describe('initTools', () => {
     expect(names).toContain('Ask-Codex');
     expect(names).not.toContain('Ask-Claude');
     expect(names).not.toContain('Ask-OpenCode');
+    expect(names).not.toContain('Ask-Cursor');
   });
 
   it('registers no tools when no CLIs available', async () => {
     vi.mocked(detectAvailableClis).mockResolvedValue({
-      gemini: false, codex: false, claude: false, opencode: false,
+      gemini: false, codex: false, claude: false, opencode: false, cursor: false,
     });
 
     await initTools();
@@ -112,7 +134,7 @@ describe('initTools', () => {
   });
 
   it('returns availability object', async () => {
-    const expected = { gemini: true, codex: false, claude: true, opencode: false };
+    const expected = { gemini: true, codex: false, claude: true, opencode: false, cursor: false };
     vi.mocked(detectAvailableClis).mockResolvedValue(expected);
 
     const result = await initTools();

--- a/tests/utils/cliDetector.test.ts
+++ b/tests/utils/cliDetector.test.ts
@@ -75,12 +75,12 @@ describe('cliDetector', () => {
       process.env.QA_NO_CLIS = 'true';
 
       const result = await detectAvailableClis();
-      expect(result).toEqual({ gemini: false, codex: false, claude: false, opencode: false });
+      expect(result).toEqual({ gemini: false, codex: false, claude: false, opencode: false, cursor: false });
       // spawn should not be called at all
       expect(spawn).not.toHaveBeenCalled();
     });
 
-    it('checks all three CLIs and returns correct availability', async () => {
+    it('checks all CLIs and returns correct availability', async () => {
       // Mock spawn to return different results for each CLI
       const mocks: ReturnType<typeof createMockChild>[] = [];
       vi.mocked(spawn).mockImplementation(() => {
@@ -92,16 +92,17 @@ describe('cliDetector', () => {
       const promise = detectAvailableClis();
 
       // Wait for all spawns to be called
-      await vi.waitFor(() => expect(mocks.length).toBe(4));
+      await vi.waitFor(() => expect(mocks.length).toBe(5));
 
-      // gemini found, codex not found, claude found, opencode not found
+      // gemini found, codex not found, claude found, opencode not found, cursor found
       mocks[0].emitClose(0); // gemini
       mocks[1].emitClose(1); // codex
       mocks[2].emitClose(0); // claude
       mocks[3].emitClose(1); // opencode
+      mocks[4].emitClose(0); // cursor
 
       const result = await promise;
-      expect(result).toEqual({ gemini: true, codex: false, claude: true, opencode: false });
+      expect(result).toEqual({ gemini: true, codex: false, claude: true, opencode: false, cursor: true });
     });
   });
 });

--- a/tests/utils/cursorExecutor.test.ts
+++ b/tests/utils/cursorExecutor.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from 'vitest';
+import { executeCursorCLI } from '../../src/utils/cursorExecutor.js';
+import { cursorListModelsTool } from '../../src/tools/simple-tools.js';
+import { executeCommand } from '../../src/utils/commandExecutor.js';
+import { CLI } from '../../src/constants.js';
+
+vi.mock('../../src/utils/commandExecutor.js', () => ({
+  executeCommand: vi.fn(),
+}));
+
+describe('executeCursorCLI', () => {
+  it('calls executeCommand with basic cursor arguments', async () => {
+    vi.mocked(executeCommand).mockResolvedValue('success');
+
+    const result = await executeCursorCLI('write a function', 'claude-3.5-sonnet');
+
+    expect(executeCommand).toHaveBeenCalledWith(
+      CLI.COMMANDS.CURSOR,
+      [
+        CLI.CURSOR_FLAGS.PRINT,
+        CLI.CURSOR_FLAGS.OUTPUT_FORMAT, 'text',
+        CLI.CURSOR_FLAGS.MODEL, 'claude-3.5-sonnet',
+        'write a function',
+      ],
+      undefined
+    );
+    expect(result).toBe('success');
+  });
+
+  it('includes optional flags when provided', async () => {
+    vi.mocked(executeCommand).mockResolvedValue('success');
+
+    await executeCursorCLI(
+      'write a function',
+      'claude-3.5-sonnet',
+      true,
+      true,
+      '/path/to/workspace'
+    );
+
+    expect(executeCommand).toHaveBeenCalledWith(
+      CLI.COMMANDS.CURSOR,
+      [
+        CLI.CURSOR_FLAGS.PRINT,
+        CLI.CURSOR_FLAGS.OUTPUT_FORMAT, 'text',
+        CLI.CURSOR_FLAGS.MODEL, 'claude-3.5-sonnet',
+        CLI.CURSOR_FLAGS.FORCE,
+        CLI.CURSOR_FLAGS.TRUST,
+        CLI.CURSOR_FLAGS.WORKSPACE, '/path/to/workspace',
+        'write a function',
+      ],
+      undefined
+    );
+  });
+});
+
+describe('cursorListModelsTool', () => {
+  it('calls executeCommand with cursor-agent --list-models', async () => {
+    vi.mocked(executeCommand).mockResolvedValue('Available models\n\nauto - Auto');
+
+    const ctx = { timeoutMs: 30_000 };
+    const result = await cursorListModelsTool.execute!({}, ctx);
+
+    expect(executeCommand).toHaveBeenCalledWith(
+      CLI.COMMANDS.CURSOR,
+      [CLI.CURSOR_FLAGS.LIST_MODELS],
+      ctx,
+    );
+    expect(result).toBe('Available models\n\nauto - Auto');
+  });
+});


### PR DESCRIPTION
## Summary
- add conditional Cursor Agent CLI detection and tool registration
- add `List-Cursor-Models`, `Ask-Cursor`, and `Cursor-Help` tools
- execute Cursor in headless mode with `cursor-agent --print --output-format text --model <model>` plus optional `--force`, `--trust`, and `--workspace`
- cover Cursor detection, registration, model listing, and executor argument construction with tests

## Tests
- `npm run lint`
- `npm test -- --run`
- `npm run build`

Implementation note: this PR is intentionally limited to Cursor Agent CLI support and does not add routing, aliases, OmniRoute, or provider selection abstractions.