### PR TITLE
feat: add OpenCode Copilot usage tool

### DIFF
--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -9,6 +9,7 @@ import { fetchChunkTool } from './fetch-chunk.tool.js';
 import { askCodexTool } from './ask-codex.tool.js';
 import { askClaudeTool } from './ask-claude.tool.js';
 import { askOpencodeTool } from './ask-opencode.tool.js';
+import { opencodeCopilotUsageTool } from './opencode-copilot-usage.tool.js';
 import { detectAvailableClis, CliAvailability } from '../utils/cliDetector.js';
 import { MultiCliConfig } from '../config.js';
 import type { Logger } from '../logger.js';
@@ -55,6 +56,7 @@ export async function initTools(
     toolRegistry.push(
       opencodeListModelsTool, // List-OpenCode-Models
       askOpencodeTool,        // Ask-OpenCode
+      opencodeCopilotUsageTool, // OpenCode-Copilot-Usage
       opencodeHelpTool,       // OpenCode-Help
     );
   }

--- a/src/tools/opencode-copilot-usage.tool.ts
+++ b/src/tools/opencode-copilot-usage.tool.ts
@@ -1,0 +1,107 @@
+import { z } from 'zod';
+import { UnifiedTool } from './registry.js';
+import { executeGhApi, GhCliError } from '../utils/githubCli.js';
+
+const currentDate = new Date();
+
+const opencodeCopilotUsageArgsSchema = z.object({
+  username: z.string().min(1).optional().describe('Optional GitHub username to inspect. Defaults to the authenticated `gh` user.'),
+  year: z.coerce.number().int().min(1970).optional().describe(`Optional year for the usage window. Defaults to ${currentDate.getFullYear()}.`),
+  month: z.coerce.number().int().min(1).max(12).optional().describe(`Optional month for the usage window. Defaults to ${currentDate.getMonth() + 1}.`),
+  day: z.coerce.number().int().min(1).max(31).optional().describe('Optional day for a more specific usage window.'),
+  product: z.string().min(1).optional().describe('Optional product filter for the usage query.'),
+  model: z.string().min(1).optional().describe('Optional model filter for the usage query.'),
+});
+
+type UsageResponse = Record<string, unknown>;
+
+async function getAuthenticatedUsername(context?: Parameters<typeof executeGhApi>[1]): Promise<string> {
+  const username = await executeGhApi(['user', '--jq', '.login'], context);
+  if (!username.trim()) {
+    throw new Error('GitHub CLI returned an empty username. Run `gh auth status` and try again.');
+  }
+
+  return username.trim();
+}
+
+function buildQueryArgs(args: {
+  year: number;
+  month: number;
+  day?: number;
+  product?: string;
+  model?: string;
+}): string[] {
+  const queryArgs = ['--method', 'GET', '-f', `year=${args.year}`, '-f', `month=${args.month}`];
+
+  if (args.day !== undefined) {
+    queryArgs.push('-f', `day=${args.day}`);
+  }
+
+  if (args.product) {
+    queryArgs.push('-f', `product=${args.product}`);
+  }
+
+  if (args.model) {
+    queryArgs.push('-f', `model=${args.model}`);
+  }
+
+  return queryArgs;
+}
+
+function formatSummary(username: string, year: number, month: number, day?: number): string {
+  const period = day ? `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}` : `${year}-${String(month).padStart(2, '0')}`;
+  return `GitHub Copilot premium request usage for ${username} (${period})`;
+}
+
+export const opencodeCopilotUsageTool: UnifiedTool = {
+  name: 'OpenCode-Copilot-Usage',
+  description: 'Check GitHub Copilot premium request usage for the authenticated OpenCode provider account or a specified GitHub username.',
+  zodSchema: opencodeCopilotUsageArgsSchema,
+  prompt: {
+    description: 'Read GitHub Copilot premium request usage for OpenCode via gh api.',
+  },
+  category: 'opencode',
+  execute: async (args, context) => {
+    const a = opencodeCopilotUsageArgsSchema.parse(args);
+    let resolvedUsername = a.username?.trim() || '';
+    let year = a.year ?? new Date().getFullYear();
+    let month = a.month ?? new Date().getMonth() + 1;
+
+    try {
+      resolvedUsername = resolvedUsername || await getAuthenticatedUsername(context);
+      const queryArgs = buildQueryArgs({
+        year,
+        month,
+        day: a.day,
+        product: a.product,
+        model: a.model,
+      });
+
+      const raw = await executeGhApi([
+        `/users/${encodeURIComponent(resolvedUsername)}/settings/billing/premium_request/usage`,
+        '-H', 'Accept: application/vnd.github+json',
+        '-H', 'X-GitHub-Api-Version: 2026-03-10',
+        ...queryArgs,
+      ], context);
+
+      const parsed = raw ? JSON.parse(raw) as UsageResponse : {};
+      return `${formatSummary(resolvedUsername, year, month, a.day)}\n\nRaw JSON:\n${JSON.stringify({
+        request: {
+          username: resolvedUsername,
+          year,
+          month,
+          day: a.day,
+          product: a.product,
+          model: a.model,
+        },
+        response: parsed,
+      }, null, 2)}`;
+    } catch (error) {
+      if (error instanceof GhCliError) {
+        return `${formatSummary(resolvedUsername, year, month, a.day)}\n\n${error.message}\n\nDebug:\n${JSON.stringify(error.details, null, 2)}`;
+      }
+
+      throw error;
+    }
+  },
+};

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -44,7 +44,7 @@ export function getToolDefinitions(subset?: UnifiedTool[]): Tool[] { // get Tool
     let annotations: Tool['annotations'] | undefined;
     if (tool.name.startsWith('Ask-')) {
       annotations = { openWorldHint: true, readOnlyHint: false, destructiveHint: false };
-    } else if (tool.name.startsWith('List-') || tool.name.endsWith('-Help') || tool.name === 'Fetch-Chunk' || tool.name === 'Claude-Gemini-Codex') {
+    } else if (tool.name.startsWith('List-') || tool.name.endsWith('-Help') || tool.name.endsWith('-Usage') || tool.name === 'Fetch-Chunk' || tool.name === 'Claude-Gemini-Codex') {
       annotations = { readOnlyHint: true, destructiveHint: false, openWorldHint: false };
     }
 

--- a/src/utils/githubCli.ts
+++ b/src/utils/githubCli.ts
@@ -1,0 +1,157 @@
+import { spawn } from 'child_process';
+import { ToolExecutionContext } from '../execution.js';
+
+export type GhFailureKind = 'missing-cli' | 'unauthenticated' | 'forbidden' | 'not-found' | 'failed';
+
+export class GhCliError extends Error {
+  constructor(
+    public readonly kind: GhFailureKind,
+    message: string,
+    public readonly details: {
+      command: string;
+      args: string[];
+      exitCode?: number | null;
+      stdout?: string;
+      stderr?: string;
+    },
+  ) {
+    super(message);
+    this.name = 'GhCliError';
+  }
+}
+
+export async function executeGhCommand(
+  args: string[],
+  context?: ToolExecutionContext,
+): Promise<string> {
+  const command = 'gh';
+  const { onProgress, signal, timeoutMs, killGraceMs = 5000, cwd, env, logger } = context ?? {};
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd,
+      env,
+      shell: false,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+    let settled = false;
+    let timeoutHandle: NodeJS.Timeout | undefined;
+    let killGraceHandle: NodeJS.Timeout | undefined;
+
+    const cleanup = () => {
+      if (timeoutHandle) clearTimeout(timeoutHandle);
+      if (killGraceHandle) clearTimeout(killGraceHandle);
+      signal?.removeEventListener('abort', onAbort);
+    };
+
+    const settleResolve = (value: string) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(value.trim());
+    };
+
+    const settleReject = (error: Error) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(error);
+    };
+
+    const killChild = (force: boolean) => {
+      child.kill(force ? 'SIGKILL' : 'SIGTERM');
+    };
+
+    const onAbort = () => {
+      killChild(false);
+      settleReject(new Error('GitHub CLI command cancelled'));
+    };
+
+    if (signal?.aborted) {
+      onAbort();
+      return;
+    }
+
+    signal?.addEventListener('abort', onAbort, { once: true });
+
+    if (timeoutMs) {
+      timeoutHandle = setTimeout(() => {
+        killChild(false);
+        killGraceHandle = setTimeout(() => killChild(true), killGraceMs);
+        settleReject(new Error(`GitHub CLI command timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+    }
+
+    logger?.info('gh_command_spawn_requested', { command, args });
+
+    child.stdout.on('data', (chunk) => {
+      const text = chunk.toString();
+      stdout += text;
+      onProgress?.(text);
+    });
+
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk.toString();
+    });
+
+    child.on('error', (error: NodeJS.ErrnoException) => {
+      if (error.code === 'ENOENT') {
+        settleReject(new GhCliError('missing-cli', 'GitHub CLI `gh` is not installed. Install it and try again.', {
+          command,
+          args,
+        }));
+        return;
+      }
+
+      settleReject(new GhCliError('failed', `Failed to start GitHub CLI: ${error.message}`, {
+        command,
+        args,
+        stderr,
+        stdout,
+      }));
+    });
+
+    child.on('close', (code) => {
+      if (code === 0) {
+        settleResolve(stdout);
+        return;
+      }
+
+      const combined = `${stderr}\n${stdout}`.toLowerCase();
+      let kind: GhFailureKind = 'failed';
+      let message = `GitHub CLI command failed with exit code ${code ?? 'unknown'}`;
+
+      if (combined.includes('not authenticated') || combined.includes('authentication failed') || combined.includes('could not find a credential')) {
+        kind = 'unauthenticated';
+        message = 'GitHub CLI is not authenticated. Run `gh auth login` (or `gh auth status`) and try again.';
+      } else if (combined.includes('missing required scope') || combined.includes('resource not accessible by personal access token') || combined.includes('insufficient scopes') || combined.includes('forbidden')) {
+        kind = 'forbidden';
+        message = 'GitHub CLI is authenticated, but the token is missing the scope needed for Copilot premium request usage. Re-authenticate with the required GitHub Copilot permissions and retry. If needed, run `gh auth refresh -h github.com -s user`.';
+      } else if (combined.includes('404 not found') || combined.includes('not found')) {
+        kind = 'not-found';
+        message = 'GitHub returned 404 for this Copilot usage request. Verify the username and requested date range, then retry.';
+      } else if (combined.includes('403 forbidden') || combined.includes('forbidden')) {
+        kind = 'forbidden';
+        message = 'GitHub returned 403 for this Copilot usage request. Check `gh auth status`, ensure the authenticated account can read Copilot premium request usage, and if needed run `gh auth refresh -h github.com -s user`.';
+      }
+
+      settleReject(new GhCliError(kind, message, {
+        command,
+        args,
+        exitCode: code,
+        stdout,
+        stderr,
+      }));
+    });
+  });
+}
+
+export async function executeGhApi(
+  args: string[],
+  context?: ToolExecutionContext,
+): Promise<string> {
+  return executeGhCommand(['api', ...args], context);
+}

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -132,6 +132,18 @@ describe('registry', () => {
       });
     });
 
+    it('adds readOnlyHint annotation to *-Usage tools', () => {
+      const tool = makeTool({ name: 'OpenCode-Copilot-Usage' });
+      toolRegistry.push(tool);
+
+      const defs = getToolDefinitions();
+      expect(defs[0].annotations).toEqual({
+        readOnlyHint: true,
+        destructiveHint: false,
+        openWorldHint: false,
+      });
+    });
+
     it('adds readOnlyHint annotation to Claude-Gemini-Codex fallback', () => {
       const tool = makeTool({ name: 'Claude-Gemini-Codex' });
       toolRegistry.push(tool);

--- a/tests/tools/initTools.test.ts
+++ b/tests/tools/initTools.test.ts
@@ -82,6 +82,7 @@ describe('initTools', () => {
     const names = toolRegistry.map(t => t.name);
     expect(names).toContain('List-OpenCode-Models');
     expect(names).toContain('Ask-OpenCode');
+    expect(names).toContain('OpenCode-Copilot-Usage');
     expect(names).toContain('OpenCode-Help');
     expect(names).not.toContain('Ask-Gemini');
     expect(names).not.toContain('Ask-Codex');

--- a/tests/tools/opencodeCopilotUsage.test.ts
+++ b/tests/tools/opencodeCopilotUsage.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../src/utils/githubCli.js', () => ({
+  executeGhApi: vi.fn(),
+  GhCliError: class GhCliError extends Error {
+    constructor(public kind: string, message: string, public details: any) {
+      super(message);
+      this.name = 'GhCliError';
+    }
+  },
+}));
+
+import { opencodeCopilotUsageTool } from '../../src/tools/opencode-copilot-usage.tool.js';
+import { executeGhApi, GhCliError } from '../../src/utils/githubCli.js';
+
+describe('opencodeCopilotUsageTool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('defaults username from gh api user and returns usage JSON', async () => {
+    vi.mocked(executeGhApi)
+      .mockResolvedValueOnce('octocat')
+      .mockResolvedValueOnce('{"total":12,"used":7}');
+
+    const result = await opencodeCopilotUsageTool.execute({}, undefined);
+
+    expect(executeGhApi).toHaveBeenNthCalledWith(1, ['user', '--jq', '.login'], undefined);
+    expect(executeGhApi).toHaveBeenNthCalledWith(2, expect.arrayContaining([
+      '--method', 'GET',
+      '/users/octocat/settings/billing/premium_request/usage',
+      '-H', 'Accept: application/vnd.github+json',
+      '-H', 'X-GitHub-Api-Version: 2026-03-10',
+      '-f', expect.stringMatching(/^year=/),
+      '-f', expect.stringMatching(/^month=/),
+    ]), undefined);
+    expect(result).toContain('GitHub Copilot premium request usage for octocat');
+    expect(result).toContain('"used": 7');
+  });
+
+  it('includes the gh error message in output for handled failures', async () => {
+    vi.mocked(executeGhApi)
+      .mockResolvedValueOnce('octocat')
+      .mockRejectedValueOnce(new GhCliError('forbidden', 'GitHub returned 403 for this Copilot usage request. Check `gh auth status`, ensure the authenticated account can read Copilot premium request usage, and if needed run `gh auth refresh -h github.com -s user`.', {
+        command: 'gh',
+        args: ['api'],
+        exitCode: 1,
+        stderr: 'HTTP 403 Forbidden',
+      }));
+
+    const result = await opencodeCopilotUsageTool.execute({}, undefined);
+
+    expect(result).toContain('GitHub returned 403 for this Copilot usage request');
+    expect(result).toContain('"command": "gh"');
+  });
+});

--- a/tests/utils/githubCli.test.ts
+++ b/tests/utils/githubCli.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'events';
+
+vi.mock('child_process', () => ({
+  spawn: vi.fn(),
+}));
+
+import { spawn } from 'child_process';
+import { executeGhApi, GhCliError } from '../../src/utils/githubCli.js';
+
+function createMockProcess() {
+  const proc = {
+    pid: 123,
+    stdout: new EventEmitter(),
+    stderr: new EventEmitter(),
+    on: vi.fn(),
+  };
+
+  const handlers: Record<string, Function> = {};
+  proc.on.mockImplementation((event: string, handler: Function) => {
+    handlers[event] = handler;
+    return proc;
+  });
+
+  return {
+    proc,
+    emitStdout(data: string) {
+      proc.stdout.emit('data', Buffer.from(data));
+    },
+    emitStderr(data: string) {
+      proc.stderr.emit('data', Buffer.from(data));
+    },
+    emitClose(code: number) {
+      handlers.close?.(code);
+    },
+    emitError(err: Error & { code?: string }) {
+      handlers.error?.(err);
+    },
+  };
+}
+
+describe('githubCli', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('executes gh api commands', async () => {
+    const mock = createMockProcess();
+    vi.mocked(spawn).mockReturnValue(mock.proc as any);
+
+    const promise = executeGhApi(['/users/octo/settings/billing/premium_request/usage']);
+    mock.emitStdout('{"ok":true}');
+    mock.emitClose(0);
+
+    await expect(promise).resolves.toBe('{"ok":true}');
+    expect(spawn).toHaveBeenCalledWith('gh', ['api', '/users/octo/settings/billing/premium_request/usage'], expect.objectContaining({ shell: false }));
+  });
+
+  it('maps missing gh to a helpful error', async () => {
+    const mock = createMockProcess();
+    vi.mocked(spawn).mockReturnValue(mock.proc as any);
+
+    const promise = executeGhApi(['/users/octo/settings/billing/premium_request/usage']);
+    mock.emitError(Object.assign(new Error('spawn gh ENOENT'), { code: 'ENOENT' }));
+
+    await expect(promise).rejects.toBeInstanceOf(GhCliError);
+    await expect(promise).rejects.toThrow('GitHub CLI `gh` is not installed');
+  });
+
+  it('maps 403 scope errors to actionable guidance', async () => {
+    const mock = createMockProcess();
+    vi.mocked(spawn).mockReturnValue(mock.proc as any);
+
+    const promise = executeGhApi(['/users/octo/settings/billing/premium_request/usage']);
+    mock.emitStderr('HTTP 403 Forbidden: missing required scope');
+    mock.emitClose(1);
+
+    await expect(promise).rejects.toThrow('missing the scope needed for Copilot premium request usage');
+  });
+
+  it('maps 404 errors to an actionable message', async () => {
+    const mock = createMockProcess();
+    vi.mocked(spawn).mockReturnValue(mock.proc as any);
+
+    const promise = executeGhApi(['/users/octo/settings/billing/premium_request/usage']);
+    mock.emitStderr('HTTP 404 Not Found');
+    mock.emitClose(1);
+
+    await expect(promise).rejects.toThrow('GitHub returned 404 for this Copilot usage request');
+  });
+
+  it('kills the gh child process on timeout', async () => {
+    vi.useFakeTimers();
+    try {
+      const mock = createMockProcess();
+      const kill = vi.fn();
+      vi.mocked(spawn).mockReturnValue({ ...mock.proc, kill } as any);
+
+      const promise = executeGhApi(['/users/octo/settings/billing/premium_request/usage'], {
+        timeoutMs: 1000,
+      });
+      vi.advanceTimersByTime(1000);
+
+      await expect(promise).rejects.toThrow('timed out');
+      expect(kill).toHaveBeenCalledWith('SIGTERM');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add OpenCode-Copilot-Usage as a read-only utility tool when OpenCode is available
- query GitHub Copilot premium request usage through the authenticated gh CLI
- add GitHub CLI helper with actionable auth/scope/not-found errors

## Tests
- ./node_modules/.bin/tsc --noEmit
- ./node_modules/.bin/vitest run tests/tools/opencodeCopilotUsage.test.ts tests/utils/githubCli.test.ts tests/tools/initTools.test.ts tests/registry.test.ts
- ./node_modules/.bin/tsc && cp src/modelCatalog.generated.json dist/modelCatalog.generated.json && ./node_modules/.bin/vitest run

Authored-by: Claude, Codex, and Gemini