### PR TITLE
Add Grok CLI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,14 @@
 [![Node](https://img.shields.io/node/v/@osanoai/multicli)](https://www.npmjs.com/package/@osanoai/multicli)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.x-3178c6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 
-**An MCP server that lets Claude, Gemini, Codex, and OpenCode call each other as tools.**
+**An MCP server that lets Claude, Gemini, Codex, OpenCode, and Grok call each other as tools.**
 
 ```
 Claude:   "Hey Gemini, what do you think about this code?"
 Gemini:   "It's mass. Let me ask Codex for a second opinion."
 Codex:    "You're both wrong. Here's the fix."
 OpenCode: "I checked with three providers. They all agree with Codex."
+Grok:     "One more angle: here's the risky edge case."
 ```
 
 ---
@@ -27,7 +28,7 @@ curl -fsSL https://raw.githubusercontent.com/osanoai/multicli/main/install.sh | 
 Detects which AI CLIs you have installed and configures Multi-CLI for them automatically.
 
 - Claude Code is configured to use a per-user local HTTP service on `127.0.0.1`
-- Gemini CLI, Codex CLI, and OpenCode keep using stdio/local config by default
+- Gemini CLI, Codex CLI, OpenCode, and Grok keep using stdio/local config by default
 - The installer may update client config files on your behalf
 
 ---
@@ -36,10 +37,11 @@ Detects which AI CLIs you have installed and configures Multi-CLI for them autom
 
 Multi-CLI sits between your AI clients and bridges them via the [Model Context Protocol](https://modelcontextprotocol.io/). Install it once, and whichever AI you're talking to gains the ability to call the others.
 
-- **Claude** can ask Gemini, Codex, or OpenCode for help
-- **Gemini** can delegate to Claude, Codex, or OpenCode
-- **Codex** can consult Claude, Gemini, or OpenCode
-- **OpenCode** can call Claude, Gemini, or Codex (across 75+ providers)
+- **Claude** can ask Gemini, Codex, OpenCode, or Grok for help
+- **Gemini** can delegate to Claude, Codex, OpenCode, or Grok
+- **Codex** can consult Claude, Gemini, OpenCode, or Grok
+- **OpenCode** can call Claude, Gemini, Codex, or Grok (across 75+ providers)
+- **Grok** can provide another local CLI perspective through the Grok Build CLI
 - Each client's own tools are hidden (no talking to yourself, that's weird)
 - Auto-detects which CLIs you have installed — only shows what's available
 
@@ -67,8 +69,10 @@ You need **Node.js >= 20** and at least **one** of these CLIs installed:
 | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `npm install -g @google/gemini-cli` |
 | [Codex CLI](https://github.com/openai/codex) | `npm install -g @openai/codex` |
 | [OpenCode](https://opencode.ai) | `curl -fsSL https://opencode.ai/install | bash` |
+| Grok Build CLI | Install `grok` from its official distribution and log in locally |
 
 > Multi-CLI is most useful with two or more CLIs installed. With only one, the install still works, but there may be nothing to bridge yet.
+> Grok support uses your local `grok` command with `grok -p <prompt>`. The CLI must already be installed, on your `PATH`, and logged in on the user machine.
 
 ---
 
@@ -242,6 +246,9 @@ Once connected, your AI client gains access to tools for the *other* CLIs (never
 | `List-OpenCode-Models` | List available OpenCode models from all configured providers |
 | `Ask-OpenCode` | Ask-OpenCode a question or give it a task |
 | `OpenCode-Help` | Get OpenCode CLI help info |
+| `List-Grok-Models` | List available Grok Build CLI models from the local CLI |
+| `Ask-Grok` | Ask Grok Build CLI a question or give it a task |
+| `Grok-Help` | Get Grok Build CLI help info |
 
 ---
 
@@ -264,6 +271,7 @@ Once installed, just talk naturally to your AI:
 "Have Codex review this function for performance issues"
 "Get Claude's opinion on this error message"
 "Use OpenCode to get a second opinion from Llama"
+"Ask Grok for another pass on this design"
 ```
 
 Or get a second opinion on anything:
@@ -306,8 +314,11 @@ For Claude Code, Multi-CLI can also run as a local background HTTP service:
 **"No usable AI CLIs detected"**
 Make sure at least one other CLI is installed and on your PATH:
 ```bash
-which gemini && which codex && which claude && which opencode
+which gemini && which codex && which claude && which opencode && which grok
 ```
+
+**Grok tools do not appear**
+Make sure `grok` is installed, available on your `PATH`, and already logged in. Multi-CLI does not configure xAI API keys, OpenRouter, or external Grok services.
 
 **No tools showing up?**
 If only your own CLI is installed, Multi-CLI hides it (no self-calls). Install a *different* CLI to enable cross-model collaboration.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osanoai/multicli",
   "version": "1.5.39",
-  "description": "MCP server for Multiple CLI coding agent integration (Claude + Gemini + Codex)",
+  "description": "MCP server for Multiple CLI coding agent integration (Claude + Gemini + Codex + OpenCode + Grok)",
   "type": "module",
   "main": "dist/index.js",
   "bin": {
@@ -25,6 +25,7 @@
     "gemini",
     "codex",
     "claude",
+    "grok",
     "cli",
     "coding",
     "agent",

--- a/src/clientFilter.ts
+++ b/src/clientFilter.ts
@@ -10,6 +10,7 @@ const CLIENT_EXCLUSIONS: Record<string, UnifiedTool['category']> = {
   'codex-mcp-client':       'codex',
   'gemini-cli-mcp-client':  'gemini',
   'opencode':               'opencode',
+  'grok':                   'grok',
 };
 
 export function getExcludedCategory(clientName: string | undefined): UnifiedTool['category'] | undefined {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,6 +15,7 @@ export const STATUS_MESSAGES = {
   CODEX_RESPONSE: "Codex response:",
   CLAUDE_RESPONSE: "Claude response:",
   OPENCODE_RESPONSE: "OpenCode response:",
+  GROK_RESPONSE: "Grok response:",
   // Timeout prevention messages
   PROCESSING_START: "🔍 Starting analysis (may take 5-15 minutes for large codebases)",
   PROCESSING_CONTINUE: "⏳ Still processing...",
@@ -56,6 +57,7 @@ export const CLI = {
     CODEX: "codex",
     CLAUDE: "claude",
     OPENCODE: "opencode",
+    GROK: "grok",
     ECHO: "echo",
   },
   // Gemini command flags
@@ -96,9 +98,18 @@ export const CLI = {
     SESSION: "-s",
     HELP: "--help",
   },
+  // Grok Build CLI flags
+  GROK_FLAGS: {
+    PROMPT: "-p",
+    HELP: "--help",
+  },
   // OpenCode subcommands
   OPENCODE_SUBCOMMANDS: {
     RUN: "run",
+    MODELS: "models",
+  },
+  // Grok subcommands
+  GROK_SUBCOMMANDS: {
     MODELS: "models",
   },
   // Default values

--- a/src/tools/ask-grok.tool.ts
+++ b/src/tools/ask-grok.tool.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+import { UnifiedTool } from './registry.js';
+import { executeGrokCLI } from '../utils/grokExecutor.js';
+import { ERROR_MESSAGES, STATUS_MESSAGES } from '../constants.js';
+
+const askGrokArgsSchema = z.object({
+  prompt: z.string().min(1).describe("The question or task for Grok. REQUIRED — MUST be a non-empty string. Grok Build CLI must already be installed and authenticated on this machine."),
+});
+
+export const askGrokTool: UnifiedTool = {
+  name: "Ask-Grok",
+  description: "Ask Grok Build CLI a question or give it a task using the locally installed, logged-in Grok CLI. This runs `grok -p <prompt>` and does not configure xAI API keys, OpenRouter, or any external service. This tool is long-running (1-15 min); delegate this call to a sub-agent or background task.",
+  zodSchema: askGrokArgsSchema,
+  prompt: {
+    description: "Execute 'grok -p <prompt>' to get Grok's response.",
+  },
+  category: 'grok',
+  execution: { taskSupport: 'optional' },
+  timeoutClass: 'ask',
+  execute: async (args, context) => {
+    const { prompt } = args;
+
+    if (!prompt?.trim()) {
+      throw new Error(ERROR_MESSAGES.NO_PROMPT_PROVIDED);
+    }
+
+    const result = await executeGrokCLI(prompt as string, context);
+
+    return `${STATUS_MESSAGES.GROK_RESPONSE}\n${result}`;
+  }
+};

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -2,13 +2,14 @@
 import { toolRegistry } from './registry.js';
 import { askGeminiTool } from './ask-gemini.tool.js';
 import {
-  geminiHelpTool, codexHelpTool, claudeHelpTool, opencodeHelpTool,
-  geminiListModelsTool, codexListModelsTool, claudeListModelsTool, opencodeListModelsTool,
+  geminiHelpTool, codexHelpTool, claudeHelpTool, opencodeHelpTool, grokHelpTool,
+  geminiListModelsTool, codexListModelsTool, claudeListModelsTool, opencodeListModelsTool, grokListModelsTool,
 } from './simple-tools.js';
 import { fetchChunkTool } from './fetch-chunk.tool.js';
 import { askCodexTool } from './ask-codex.tool.js';
 import { askClaudeTool } from './ask-claude.tool.js';
 import { askOpencodeTool } from './ask-opencode.tool.js';
+import { askGrokTool } from './ask-grok.tool.js';
 import { detectAvailableClis, CliAvailability } from '../utils/cliDetector.js';
 import { MultiCliConfig } from '../config.js';
 import type { Logger } from '../logger.js';
@@ -56,6 +57,14 @@ export async function initTools(
       opencodeListModelsTool, // List-OpenCode-Models
       askOpencodeTool,        // Ask-OpenCode
       opencodeHelpTool,       // OpenCode-Help
+    );
+  }
+
+  if (availability.grok) {
+    toolRegistry.push(
+      grokListModelsTool,    // List-Grok-Models
+      askGrokTool,            // Ask-Grok
+      grokHelpTool,           // Grok-Help
     );
   }
 

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -19,7 +19,7 @@ export interface UnifiedTool {
   };
   
   execute: (args: ToolArguments, context?: ToolExecutionContext) => Promise<string>;
-  category?: 'gemini' | 'codex' | 'claude' | 'opencode' | 'utility';
+  category?: 'gemini' | 'codex' | 'claude' | 'opencode' | 'grok' | 'utility';
   execution?: Tool['execution'];
   timeoutClass?: ToolTimeoutClass;
 }

--- a/src/tools/simple-tools.ts
+++ b/src/tools/simple-tools.ts
@@ -95,6 +95,30 @@ export const opencodeHelpTool: UnifiedTool = {
   execute: async (_args, context) => executeCommand("opencode", ["--help"], context),
 };
 
+export const grokHelpTool: UnifiedTool = {
+  name: "Grok-Help",
+  description: "Receive help information from the Grok Build CLI",
+  zodSchema: helpArgsSchema,
+  prompt: {
+    description: "Receive help information from the Grok Build CLI",
+  },
+  category: 'grok',
+  timeoutClass: 'help',
+  execute: async (_args, context) => executeCommand("grok", ["--help"], context),
+};
+
+export const grokListModelsTool: UnifiedTool = {
+  name: "List-Grok-Models",
+  description: "List available Grok Build CLI models discovered by the local Grok CLI. You MAY call this before Ask-Grok if you need to inspect the local/default model configuration.",
+  zodSchema: noArgsSchema,
+  prompt: {
+    description: "List available Grok Build CLI models",
+  },
+  category: 'grok',
+  timeoutClass: 'help',
+  execute: async (_args, context) => executeCommand("grok", ["models"], context),
+};
+
 export const opencodeListModelsTool: UnifiedTool = {
   name: "List-OpenCode-Models",
   description: "List available OpenCode models from all configured providers, classified into tiers. You MUST call this before Ask-OpenCode to choose the right model for your task. Models are dynamically discovered from your providers.",

--- a/src/utils/cliDetector.ts
+++ b/src/utils/cliDetector.ts
@@ -81,11 +81,12 @@ export interface CliAvailability {
   codex: boolean;
   claude: boolean;
   opencode: boolean;
+  grok: boolean;
 }
 
 /**
- * Detect which of the four supported CLIs are available on the system.
- * Runs all four checks in parallel for speed.
+ * Detect which supported CLIs are available on the system.
+ * Runs all checks in parallel for speed.
  */
 export async function detectAvailableClis(
   timeoutMs?: number,
@@ -95,18 +96,19 @@ export async function detectAvailableClis(
     logger?.info('cli_detection_skipped', {
       reason: 'QA_NO_CLIS=true',
     });
-    return { gemini: false, codex: false, claude: false, opencode: false };
+    return { gemini: false, codex: false, claude: false, opencode: false, grok: false };
   }
 
   logger?.info('cli_detection_started', { timeoutMs });
-  const [gemini, codex, claude, opencode] = await Promise.all([
+  const [gemini, codex, claude, opencode, grok] = await Promise.all([
     commandExists(CLI.COMMANDS.GEMINI, timeoutMs, logger),
     commandExists(CLI.COMMANDS.CODEX, timeoutMs, logger),
     commandExists(CLI.COMMANDS.CLAUDE, timeoutMs, logger),
     commandExists(CLI.COMMANDS.OPENCODE, timeoutMs, logger),
+    commandExists(CLI.COMMANDS.GROK, timeoutMs, logger),
   ]);
 
-  const availability: CliAvailability = { gemini, codex, claude, opencode };
+  const availability: CliAvailability = { gemini, codex, claude, opencode, grok };
   logger?.info('cli_detection_finished', { availability });
 
   return availability;

--- a/src/utils/grokExecutor.ts
+++ b/src/utils/grokExecutor.ts
@@ -1,0 +1,14 @@
+import { executeCommand } from './commandExecutor.js';
+import { CLI } from '../constants.js';
+import { ToolExecutionContext } from '../execution.js';
+
+export async function executeGrokCLI(
+  prompt: string,
+  context?: ToolExecutionContext,
+): Promise<string> {
+  return executeCommand(
+    CLI.COMMANDS.GROK,
+    [CLI.GROK_FLAGS.PROMPT, prompt],
+    context,
+  );
+}

--- a/tests/clientFilter.test.ts
+++ b/tests/clientFilter.test.ts
@@ -31,6 +31,10 @@ describe('getExcludedCategory', () => {
     expect(getExcludedCategory('gemini-cli-mcp-client')).toBe('gemini');
   });
 
+  it('should map "grok" to "grok"', () => {
+    expect(getExcludedCategory('grok')).toBe('grok');
+  });
+
   it('should return undefined for an unknown client name', () => {
     expect(getExcludedCategory('unknown-client')).toBeUndefined();
   });
@@ -49,13 +53,14 @@ describe('filterToolsForClient', () => {
     mockTool('ask-gemini', 'gemini'),
     mockTool('ask-codex', 'codex'),
     mockTool('ask-claude', 'claude'),
+    mockTool('ask-grok', 'grok'),
     mockTool('fetch-chunk', 'utility'),
   ];
 
   it('should remove tools matching the excluded category', () => {
     const result = filterToolsForClient(tools, 'claude-code');
 
-    expect(result).toHaveLength(3);
+    expect(result).toHaveLength(4);
     expect(result.map(t => t.name)).not.toContain('ask-claude');
     expect(result.map(t => t.name)).toContain('ask-gemini');
     expect(result.map(t => t.name)).toContain('ask-codex');
@@ -65,19 +70,19 @@ describe('filterToolsForClient', () => {
   it('should return all tools for an unknown client name', () => {
     const result = filterToolsForClient(tools, 'some-random-client');
 
-    expect(result).toHaveLength(4);
+    expect(result).toHaveLength(5);
     expect(result).toEqual(tools);
   });
 
   it('should return all tools when clientName is undefined', () => {
     const result = filterToolsForClient(tools, undefined);
 
-    expect(result).toHaveLength(4);
+    expect(result).toHaveLength(5);
     expect(result).toEqual(tools);
   });
 
   it('should preserve utility tools for all known clients', () => {
-    for (const client of ['claude-code', 'codex-mcp-client', 'gemini-cli-mcp-client']) {
+    for (const client of ['claude-code', 'codex-mcp-client', 'gemini-cli-mcp-client', 'grok']) {
       const result = filterToolsForClient(tools, client);
       expect(result.map(t => t.name)).toContain('fetch-chunk');
     }

--- a/tests/httpServer.test.ts
+++ b/tests/httpServer.test.ts
@@ -99,6 +99,7 @@ describe.skipIf(!canBindLoopback)('httpServer', () => {
       codex: false,
       claude: true,
       opencode: false,
+      grok: false,
     });
   });
 

--- a/tests/serverApp.test.ts
+++ b/tests/serverApp.test.ts
@@ -45,6 +45,7 @@ async function createConnectedPair(options?: CreateServerAppOptions) {
     codex: false,
     claude: true,
     opencode: false,
+    grok: false,
   });
 
   const app = await createServerApp(TEST_CONFIG, undefined, options);

--- a/tests/tools/initTools.test.ts
+++ b/tests/tools/initTools.test.ts
@@ -24,7 +24,7 @@ describe('initTools', () => {
 
   it('registers gemini tools when gemini available', async () => {
     vi.mocked(detectAvailableClis).mockResolvedValue({
-      gemini: true, codex: false, claude: false, opencode: false,
+      gemini: true, codex: false, claude: false, opencode: false, grok: false,
     });
 
     await initTools();
@@ -38,11 +38,12 @@ describe('initTools', () => {
     expect(names).not.toContain('Ask-Codex');
     expect(names).not.toContain('Ask-Claude');
     expect(names).not.toContain('Ask-OpenCode');
+    expect(names).not.toContain('Ask-Grok');
   });
 
   it('registers codex tools when codex available', async () => {
     vi.mocked(detectAvailableClis).mockResolvedValue({
-      gemini: false, codex: true, claude: false, opencode: false,
+      gemini: false, codex: true, claude: false, opencode: false, grok: false,
     });
 
     await initTools();
@@ -54,11 +55,12 @@ describe('initTools', () => {
     expect(names).not.toContain('Ask-Gemini');
     expect(names).not.toContain('Ask-Claude');
     expect(names).not.toContain('Ask-OpenCode');
+    expect(names).not.toContain('Ask-Grok');
   });
 
   it('registers claude tools when claude available', async () => {
     vi.mocked(detectAvailableClis).mockResolvedValue({
-      gemini: false, codex: false, claude: true, opencode: false,
+      gemini: false, codex: false, claude: true, opencode: false, grok: false,
     });
 
     await initTools();
@@ -70,11 +72,12 @@ describe('initTools', () => {
     expect(names).not.toContain('Ask-Gemini');
     expect(names).not.toContain('Ask-Codex');
     expect(names).not.toContain('Ask-OpenCode');
+    expect(names).not.toContain('Ask-Grok');
   });
 
   it('registers opencode tools when opencode available', async () => {
     vi.mocked(detectAvailableClis).mockResolvedValue({
-      gemini: false, codex: false, claude: false, opencode: true,
+      gemini: false, codex: false, claude: false, opencode: true, grok: false,
     });
 
     await initTools();
@@ -86,11 +89,29 @@ describe('initTools', () => {
     expect(names).not.toContain('Ask-Gemini');
     expect(names).not.toContain('Ask-Codex');
     expect(names).not.toContain('Ask-Claude');
+    expect(names).not.toContain('Ask-Grok');
+  });
+
+  it('registers grok tools when grok available', async () => {
+    vi.mocked(detectAvailableClis).mockResolvedValue({
+      gemini: false, codex: false, claude: false, opencode: false, grok: true,
+    });
+
+    await initTools();
+
+    const names = toolRegistry.map(t => t.name);
+    expect(names).toContain('List-Grok-Models');
+    expect(names).toContain('Ask-Grok');
+    expect(names).toContain('Grok-Help');
+    expect(names).not.toContain('Ask-Gemini');
+    expect(names).not.toContain('Ask-Codex');
+    expect(names).not.toContain('Ask-Claude');
+    expect(names).not.toContain('Ask-OpenCode');
   });
 
   it('registers tools for multiple available CLIs', async () => {
     vi.mocked(detectAvailableClis).mockResolvedValue({
-      gemini: true, codex: true, claude: false, opencode: false,
+      gemini: true, codex: true, claude: false, opencode: false, grok: true,
     });
 
     await initTools();
@@ -98,13 +119,15 @@ describe('initTools', () => {
     const names = toolRegistry.map(t => t.name);
     expect(names).toContain('Ask-Gemini');
     expect(names).toContain('Ask-Codex');
+    expect(names).toContain('List-Grok-Models');
+    expect(names).toContain('Ask-Grok');
     expect(names).not.toContain('Ask-Claude');
     expect(names).not.toContain('Ask-OpenCode');
   });
 
   it('registers no tools when no CLIs available', async () => {
     vi.mocked(detectAvailableClis).mockResolvedValue({
-      gemini: false, codex: false, claude: false, opencode: false,
+      gemini: false, codex: false, claude: false, opencode: false, grok: false,
     });
 
     await initTools();
@@ -112,7 +135,7 @@ describe('initTools', () => {
   });
 
   it('returns availability object', async () => {
-    const expected = { gemini: true, codex: false, claude: true, opencode: false };
+    const expected = { gemini: true, codex: false, claude: true, opencode: false, grok: true };
     vi.mocked(detectAvailableClis).mockResolvedValue(expected);
 
     const result = await initTools();

--- a/tests/utils/cliDetector.test.ts
+++ b/tests/utils/cliDetector.test.ts
@@ -75,12 +75,12 @@ describe('cliDetector', () => {
       process.env.QA_NO_CLIS = 'true';
 
       const result = await detectAvailableClis();
-      expect(result).toEqual({ gemini: false, codex: false, claude: false, opencode: false });
+      expect(result).toEqual({ gemini: false, codex: false, claude: false, opencode: false, grok: false });
       // spawn should not be called at all
       expect(spawn).not.toHaveBeenCalled();
     });
 
-    it('checks all three CLIs and returns correct availability', async () => {
+    it('checks all supported CLIs and returns correct availability', async () => {
       // Mock spawn to return different results for each CLI
       const mocks: ReturnType<typeof createMockChild>[] = [];
       vi.mocked(spawn).mockImplementation(() => {
@@ -92,16 +92,17 @@ describe('cliDetector', () => {
       const promise = detectAvailableClis();
 
       // Wait for all spawns to be called
-      await vi.waitFor(() => expect(mocks.length).toBe(4));
+      await vi.waitFor(() => expect(mocks.length).toBe(5));
 
-      // gemini found, codex not found, claude found, opencode not found
+      // gemini found, codex not found, claude found, opencode not found, grok found
       mocks[0].emitClose(0); // gemini
       mocks[1].emitClose(1); // codex
       mocks[2].emitClose(0); // claude
       mocks[3].emitClose(1); // opencode
+      mocks[4].emitClose(0); // grok
 
       const result = await promise;
-      expect(result).toEqual({ gemini: true, codex: false, claude: true, opencode: false });
+      expect(result).toEqual({ gemini: true, codex: false, claude: true, opencode: false, grok: true });
     });
   });
 });

--- a/tests/utils/grokExecutor.test.ts
+++ b/tests/utils/grokExecutor.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../src/utils/commandExecutor.js', () => ({
+  executeCommand: vi.fn().mockResolvedValue('mock grok response'),
+}));
+
+import { executeGrokCLI } from '../../src/utils/grokExecutor.js';
+import { executeCommand } from '../../src/utils/commandExecutor.js';
+
+describe('grokExecutor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('calls grok with headless prompt flag', async () => {
+    const result = await executeGrokCLI('explain this code');
+
+    expect(executeCommand).toHaveBeenCalledWith(
+      'grok',
+      ['-p', 'explain this code'],
+      undefined,
+    );
+    expect(result).toBe('mock grok response');
+  });
+
+  it('passes onProgress callback through', async () => {
+    const onProgress = vi.fn();
+    await executeGrokCLI('test prompt', { onProgress });
+
+    expect(executeCommand).toHaveBeenCalledWith(
+      'grok',
+      ['-p', 'test prompt'],
+      { onProgress },
+    );
+  });
+});


### PR DESCRIPTION
**Add Grok Build CLI support to Multi-CLI.**

This PR adds support for detecting and using the local Grok CLI as part of Multi-CLI’s MCP toolset.

**Changes**

Adds Grok CLI detection.
Adds Ask-Grok for sending prompts to the local Grok CLI.
Adds Grok-Help for retrieving Grok CLI help output.
Adds List-Grok-Models for listing locally available Grok models.
Uses the local logged-in Grok CLI via grok -p.
Does not add xAI API keys, external API calls, OpenRouter, or any hosted service dependency.
Updates README documentation.
Adds/updates tests for Grok detection and tool registration.

**Validation**

npm run lint passed.
npm run build passed.
npm run test passed.
MCP tools/list returned the Grok tools successfully.
Local Grok CLI runtime test passed.
Ask-Grok, Grok-Help, and List-Grok-Models were discovered successfully alongside the existing Multi-CLI tools.

**Notes**

Grok support requires the official Grok Build CLI to be installed and authenticated locally on the user’s machine.