### PR TITLE
Fix systemd service install

### DIFF
--- a/src/service/manager.ts
+++ b/src/service/manager.ts
@@ -54,6 +54,16 @@ function writeTextFile(filePath: string, contents: string, mode?: number) {
   }
 }
 
+export function ensureServiceFilesystem(manifest: ServiceManifest) {
+  mkdirSync(manifest.paths.root, { recursive: true });
+  ensureParentDir(manifest.paths.envFile);
+  ensureParentDir(manifest.paths.launcher);
+  ensureParentDir(manifest.paths.serviceDefinition);
+  ensureParentDir(manifest.paths.manifest);
+  ensureParentDir(manifest.paths.logFile);
+  ensureParentDir(manifest.paths.stderrLogFile);
+}
+
 function loadManifest(config: MultiCliConfig): ServiceManifest {
   const manifestPath = config.serviceManifestPath;
   if (!existsSync(manifestPath)) {
@@ -266,7 +276,7 @@ async function installService(
     token,
   );
 
-  mkdirSync(manifest.paths.root, { recursive: true });
+  ensureServiceFilesystem(manifest);
   writeTextFile(
     manifest.paths.envFile,
     buildServiceEnvFileContents(manifest),

--- a/src/service/renderers.ts
+++ b/src/service/renderers.ts
@@ -19,6 +19,20 @@ function quotePowerShell(value: string): string {
   return `'${value.replaceAll("'", "''")}'`;
 }
 
+function escapeSystemdPath(value: string): string {
+  return Array.from(Buffer.from(value, 'utf8'))
+    .map((byte) => {
+      const char = String.fromCharCode(byte);
+      if (char === '%') {
+        return '%%';
+      }
+      return /[A-Za-z0-9/_.:-]/.test(char)
+        ? char
+        : `\\x${byte.toString(16).padStart(2, '0')}`;
+    })
+    .join('');
+}
+
 export function renderPosixLauncher(manifest: ServiceManifest): string {
   return `#!/bin/sh
 set -eu
@@ -68,12 +82,12 @@ After=network.target
 
 [Service]
 Type=simple
-WorkingDirectory=${JSON.stringify(manifest.paths.root)}
-ExecStart=${JSON.stringify(manifest.paths.launcher)}
+WorkingDirectory=${escapeSystemdPath(manifest.paths.root)}
+ExecStart=${escapeSystemdPath(manifest.paths.launcher)}
 Restart=on-failure
 RestartSec=1
-StandardOutput=append:${JSON.stringify(manifest.paths.logFile)}
-StandardError=append:${JSON.stringify(manifest.paths.stderrLogFile)}
+StandardOutput=append:${escapeSystemdPath(manifest.paths.logFile)}
+StandardError=append:${escapeSystemdPath(manifest.paths.stderrLogFile)}
 
 [Install]
 WantedBy=default.target

--- a/tests/service.test.ts
+++ b/tests/service.test.ts
@@ -1,13 +1,13 @@
 import os from 'node:os';
 import path from 'node:path';
-import { rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 
 import { describe, expect, it } from 'vitest';
 
 import type { MultiCliConfig } from '../src/config.js';
 import { getServiceKind, getServicePaths } from '../src/service/paths.js';
 import { loadServiceEnvironment } from '../src/service/bootstrap.js';
-import { isMatchingClaudeConfigOutput } from '../src/service/manager.js';
+import { ensureServiceFilesystem, isMatchingClaudeConfigOutput } from '../src/service/manager.js';
 import {
   buildServiceEnvFileContents,
   createServiceManifest,
@@ -143,9 +143,79 @@ describe('service renderers', () => {
     expect(renderWindowsTaskXml(createServiceManifest(createConfig(), 'token-value', 'win32')))
       .toContain('<LogonTrigger>');
   });
+
+  it('renders systemd unit paths without quoted path values', () => {
+    const manifest = createServiceManifest(createConfig({
+      serviceRootDir: '/home/example/.config/multicli',
+      serviceLogPath: '/home/example/.config/multicli/logs/service.log',
+      serviceEnvPath: '/home/example/.config/multicli/env',
+      serviceManifestPath: '/home/example/.config/multicli/manifest.json',
+    }), 'token-value', 'linux');
+    const unit = renderSystemdUnit(manifest);
+
+    expect(unit).toContain('WorkingDirectory=/home/example/.config/multicli');
+    expect(unit).toContain('ExecStart=/home/example/.config/multicli/launcher.sh');
+    expect(unit).toContain('StandardOutput=append:/home/example/.config/multicli/logs/service.log');
+    expect(unit).toContain('StandardError=append:/home/example/.config/multicli/logs/service.log.stderr');
+    expect(unit).not.toContain('WorkingDirectory="');
+    expect(unit).not.toContain('append:"');
+  });
+
+  it('escapes systemd unit paths with spaces', () => {
+    const manifest = createServiceManifest(createConfig({
+      serviceRootDir: '/home/example/Multi CLI',
+      serviceLogPath: '/home/example/Multi CLI/logs/service.log',
+      serviceEnvPath: '/home/example/Multi CLI/env',
+      serviceManifestPath: '/home/example/Multi CLI/manifest.json',
+    }), 'token-value', 'linux');
+    const unit = renderSystemdUnit(manifest);
+
+    expect(unit).toContain('WorkingDirectory=/home/example/Multi\\x20CLI');
+    expect(unit).toContain('ExecStart=/home/example/Multi\\x20CLI/launcher.sh');
+    expect(unit).toContain('StandardOutput=append:/home/example/Multi\\x20CLI/logs/service.log');
+    expect(unit).toContain('StandardError=append:/home/example/Multi\\x20CLI/logs/service.log.stderr');
+  });
+
+  it('escapes literal percent characters in systemd unit paths', () => {
+    const manifest = createServiceManifest(createConfig({
+      serviceRootDir: '/home/example/Multi%CLI',
+      serviceLogPath: '/home/example/Multi%CLI/logs/service.log',
+      serviceEnvPath: '/home/example/Multi%CLI/env',
+      serviceManifestPath: '/home/example/Multi%CLI/manifest.json',
+    }), 'token-value', 'linux');
+    const unit = renderSystemdUnit(manifest);
+
+    expect(unit).toContain('WorkingDirectory=/home/example/Multi%%CLI');
+    expect(unit).toContain('ExecStart=/home/example/Multi%%CLI/launcher.sh');
+    expect(unit).toContain('StandardOutput=append:/home/example/Multi%%CLI/logs/service.log');
+    expect(unit).toContain('StandardError=append:/home/example/Multi%%CLI/logs/service.log.stderr');
+    expect(unit).not.toContain('\\x25');
+  });
 });
 
 describe('service manager', () => {
+  it('creates directories required before systemd starts the service', () => {
+    const tempRoot = mkdtempSync(path.join(os.tmpdir(), 'multicli-service-fs-'));
+    const serviceRootDir = path.join(tempRoot, 'service');
+    const manifest = createServiceManifest(createConfig({
+      serviceRootDir,
+      serviceLogPath: path.join(serviceRootDir, 'logs', 'service.log'),
+      serviceEnvPath: path.join(serviceRootDir, 'env'),
+      serviceManifestPath: path.join(serviceRootDir, 'manifest.json'),
+    }), 'token-value', 'linux');
+
+    try {
+      ensureServiceFilesystem(manifest);
+
+      expect(existsSync(manifest.paths.root)).toBe(true);
+      expect(existsSync(path.dirname(manifest.paths.logFile))).toBe(true);
+      expect(existsSync(path.dirname(manifest.paths.stderrLogFile))).toBe(true);
+      expect(existsSync(path.dirname(manifest.paths.serviceDefinition))).toBe(true);
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
   it('matches Claude MCP output only for the managed HTTP config', () => {
     const manifest = createServiceManifest(createConfig(), 'token-value', 'darwin');
 


### PR DESCRIPTION
## Summary
- render systemd service paths with unit-safe escaping instead of JSON quotes
- create all service parent directories, including append log directories, before registering the service
- add regression tests for systemd path rendering and service filesystem setup

## Verification
- npm test -- tests/service.test.ts
- npm run lint
- npm run build
- npm test
- systemd-analyze --user verify ~/.config/systemd/user/multicli.service
- multicli service refresh --configure-claude
- multicli service doctor
- curl -fsS http://127.0.0.1:37420/health

Authored by Claude, Codex, and Gemini.