### PR TITLE
fix: restore codex model catalog extraction (path moved) + refresh to gpt-5.6

### DIFF
--- a/scripts/extract-codex.sh
+++ b/scripts/extract-codex.sh
@@ -4,7 +4,12 @@
 # Use a unique temporary directory
 TMP_DIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'codex-extract')
 REPO_URL="${CODEX_REPO_URL:-https://github.com/openai/codex}"
-MODELS_FILE="codex-rs/core/models.json"
+# Codex moved the bundled model metadata from core/ to models-manager/.
+# Try the new location first, then fall back to the old one for older refs.
+MODELS_FILES=(
+    "codex-rs/models-manager/models.json"
+    "codex-rs/core/models.json"
+)
 
 # Function to clean up on exit
 cleanup() {
@@ -20,18 +25,26 @@ fi
 
 cd "$TMP_DIR" || { echo "[]"; exit 0; }
 
-# 2. Attempt to checkout the models file from main
-if ! git checkout main -- "$MODELS_FILE" > /dev/null 2>&1; then
-    # Fallback to master if main failed
-    if ! git checkout master -- "$MODELS_FILE" > /dev/null 2>&1; then
-        echo "[]"
-        exit 0
-    fi
+# 2. Attempt to checkout the models file: try each branch (main, master)
+#    against each candidate path, and use the first one that exists.
+MODELS_FILE=""
+for branch in main master; do
+    for candidate in "${MODELS_FILES[@]}"; do
+        if git checkout "$branch" -- "$candidate" > /dev/null 2>&1; then
+            MODELS_FILE="$candidate"
+            break 2
+        fi
+    done
+done
+
+if [ -z "$MODELS_FILE" ]; then
+    echo "[]"
+    exit 0
 fi
 
-# 3. Extract slugs using jq and output as a JSON array to stdout
+# 3. Extract gpt- slugs using jq and output as a JSON array to stdout
 if [ -f "$MODELS_FILE" ]; then
-    RESULT=$(jq -c '[.models[].slug | select(contains("oss") | not)] | unique' "$MODELS_FILE")
+    RESULT=$(jq -c '[.models[].slug | select(startswith("gpt-")) | select(contains("oss") | not)] | unique' "$MODELS_FILE")
 else
     RESULT="[]"
 fi

--- a/src/modelCatalog.generated.json
+++ b/src/modelCatalog.generated.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-18T09:19:53.537Z",
+  "generatedAt": "2026-07-11T00:00:00.000Z",
   "catalogs": {
     "claude": {
       "cli": "claude",
@@ -38,13 +38,16 @@
           "tier": "balanced",
           "models": [
             "gpt-5.2",
-            "gpt-5.3-codex"
+            "gpt-5.4",
+            "gpt-5.5"
           ]
         },
         {
           "tier": "powerful",
           "models": [
-            "gpt-5.4"
+            "gpt-5.6-luna",
+            "gpt-5.6-sol",
+            "gpt-5.6-terra"
           ]
         }
       ]


### PR DESCRIPTION
## Problem

`scripts/extract-codex.sh` reads `codex-rs/core/models.json` from the upstream `openai/codex` repo, but that file was **moved to `codex-rs/models-manager/models.json`** (the old path now 404s). As a result:

- extraction returns `[]`
- `refresh-catalog.ts` falls back to the previous catalog
- the nightly **Refresh Model Catalog** workflow has been a silent no-op for codex, freezing the catalog at `gpt-5.4` (generatedAt 2026-04-18)

Meanwhile upstream shipped `gpt-5.5` and the three `gpt-5.6` variants, and dropped `gpt-5.3-codex`.

## Fix

- **`scripts/extract-codex.sh`**: probe `codex-rs/models-manager/models.json` first, fall back to `codex-rs/core/models.json`, across `main`/`master`. Restrict the jq filter to `gpt-` slugs (excluding `oss`).
- **`src/modelCatalog.generated.json`** (codex): mirror the current upstream lineup — add `gpt-5.5`, `gpt-5.6-luna`, `gpt-5.6-sol`, `gpt-5.6-terra`; remove the now-absent `gpt-5.3-codex`. Interim tiering; the nightly CI will re-enrich once extraction works again.

Verified against the live `models.json`, the fixed extraction yields:
`["gpt-5.2","gpt-5.4","gpt-5.4-mini","gpt-5.5","gpt-5.6-luna","gpt-5.6-sol","gpt-5.6-terra"]`

## Test plan

- [x] `bash scripts/extract-codex.sh` (equiv. jq) yields the 7 gpt- slugs above against the live upstream `models.json`
- [x] `npm run build` succeeds; `dist/modelCatalog.generated.json` reflects the new set
- [x] `formatCatalog('codex')` renders gpt-5.6 in the powerful tier with no load error
- [x] `npx vitest run refresh-catalog modelCatalog` — 27/27 pass
- [ ] Nightly `Refresh Model Catalog` workflow re-enriches tiers on a live run (post-merge)