### PR TITLE
fix: detect codex CLI flag support instead of always sending --full-auto

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -78,9 +78,22 @@ export const CLI = {
     MODEL: "-m",
     SANDBOX: "-s",
     APPROVAL: "-a",
+    CONFIG: "-c",
     COLOR: "--color",
+    // Removed from `codex exec` in newer CLI versions — kept for older installs.
     FULL_AUTO: "--full-auto",
+    ASK_FOR_APPROVAL: "--ask-for-approval",
+    // Replacement for --full-auto. Mutually exclusive with -s/--sandbox.
+    APPROVE_FOR_ME: "--approve-for-me",
     SKIP_GIT_CHECK: "--skip-git-repo-check",
+    HELP: "--help",
+  },
+  // Config override used when the -a flag is unavailable
+  CODEX_CONFIG_KEYS: {
+    APPROVAL_POLICY: "approval_policy",
+  },
+  CODEX_APPROVAL_POLICIES: {
+    NEVER: "never",
   },
   // Claude Code flags
   CLAUDE_FLAGS: {

--- a/src/tools/ask-codex.tool.ts
+++ b/src/tools/ask-codex.tool.ts
@@ -15,7 +15,7 @@ export const askCodexTool: UnifiedTool = {
   description: "Ask OpenAI Codex a question or give it a task. Codex has full filesystem access and will read files itself — do NOT pre-gather context or inline file contents into the prompt. Just describe what you need. You MUST call List-Codex-Models first to select an appropriate model. Do NOT set optional parameters unless you have a specific reason. This tool is long-running (1-15 min); delegate this call to a sub-agent or background task.",
   zodSchema: askCodexArgsSchema,
   prompt: {
-    description: "Execute 'codex exec <prompt> --full-auto' to get Codex's response.",
+    description: "Execute 'codex exec <prompt>' unattended to get Codex's response.",
   },
   category: 'codex',
   execution: { taskSupport: 'optional' },

--- a/src/utils/codexCapabilities.ts
+++ b/src/utils/codexCapabilities.ts
@@ -1,0 +1,71 @@
+import { executeCommand } from './commandExecutor.js';
+import { CLI } from '../constants.js';
+import { ToolExecutionContext } from '../execution.js';
+
+/**
+ * Flag support of the installed Codex CLI.
+ *
+ * `codex exec` dropped `--full-auto` and `-a/--ask-for-approval` in newer releases,
+ * replacing them with `--approve-for-me` and `-c approval_policy=<value>`. Version
+ * numbers don't tell us reliably when that happened, so we read the CLI's own help
+ * output instead.
+ */
+export interface CodexCapabilities {
+  approveForMe: boolean;
+  askForApprovalFlag: boolean;
+}
+
+const LEGACY_CAPABILITIES: CodexCapabilities = {
+  approveForMe: false,
+  askForApprovalFlag: true,
+};
+
+const PROBE_TIMEOUT_MS = 15000;
+
+let cached: Promise<CodexCapabilities> | undefined;
+
+/** Clear the per-process probe result. Test seam. */
+export function resetCodexCapabilitiesCache(): void {
+  cached = undefined;
+}
+
+async function probeCodexCapabilities(context: ToolExecutionContext): Promise<CodexCapabilities> {
+  // Help output is noise for the caller — never stream it through onProgress.
+  const { onProgress: _onProgress, ...probeContext } = context;
+
+  const help = await executeCommand(
+    CLI.COMMANDS.CODEX,
+    [CLI.SUBCOMMANDS.EXEC, CLI.CODEX_FLAGS.HELP],
+    { ...probeContext, timeoutMs: probeContext.timeoutMs ?? PROBE_TIMEOUT_MS },
+  );
+
+  const capabilities: CodexCapabilities = {
+    approveForMe: help.includes(CLI.CODEX_FLAGS.APPROVE_FOR_ME),
+    askForApprovalFlag: help.includes(CLI.CODEX_FLAGS.ASK_FOR_APPROVAL),
+  };
+
+  context.logger?.info('codex_capabilities_detected', { capabilities });
+
+  return capabilities;
+}
+
+export async function getCodexCapabilities(
+  context: ToolExecutionContext = {},
+): Promise<CodexCapabilities> {
+  if (cached) {
+    return cached;
+  }
+
+  const pending: Promise<CodexCapabilities> = probeCodexCapabilities(context).catch((error) => {
+    // A transient probe failure must not pin legacy flags for the rest of the process.
+    if (cached === pending) {
+      cached = undefined;
+    }
+    context.logger?.error('codex_capability_probe_failed', { error });
+    return LEGACY_CAPABILITIES;
+  });
+
+  cached = pending;
+
+  return pending;
+}

--- a/src/utils/codexExecutor.ts
+++ b/src/utils/codexExecutor.ts
@@ -1,4 +1,5 @@
 import { executeCommand } from './commandExecutor.js';
+import { getCodexCapabilities } from './codexCapabilities.js';
 import { CLI } from '../constants.js';
 import { ToolExecutionContext } from '../execution.js';
 
@@ -9,20 +10,44 @@ export async function executeCodexCLI(
   approvalPolicy?: string,
   context?: ToolExecutionContext,
 ): Promise<string> {
-  const args: string[] = [
-    CLI.SUBCOMMANDS.EXEC, prompt,
-    CLI.CODEX_FLAGS.FULL_AUTO,
+  const capabilities = await getCodexCapabilities(context);
+
+  const args: string[] = [CLI.SUBCOMMANDS.EXEC, prompt];
+
+  if (capabilities.approveForMe) {
+    // --approve-for-me is rejected alongside -s, so an explicit sandbox wins and
+    // the run is kept unattended through approval_policy below instead.
+    if (!sandbox) {
+      args.push(CLI.CODEX_FLAGS.APPROVE_FOR_ME);
+    }
+  } else {
+    args.push(CLI.CODEX_FLAGS.FULL_AUTO);
+  }
+
+  args.push(
     CLI.CODEX_FLAGS.SKIP_GIT_CHECK,
     CLI.CODEX_FLAGS.COLOR, "never",
     CLI.CODEX_FLAGS.MODEL, model,
-  ];
+  );
 
   if (sandbox) {
     args.push(CLI.CODEX_FLAGS.SANDBOX, sandbox);
   }
 
-  if (approvalPolicy) {
-    args.push(CLI.CODEX_FLAGS.APPROVAL, approvalPolicy);
+  if (capabilities.askForApprovalFlag) {
+    if (approvalPolicy) {
+      args.push(CLI.CODEX_FLAGS.APPROVAL, approvalPolicy);
+    }
+  } else {
+    const policy = approvalPolicy
+      ?? (sandbox ? CLI.CODEX_APPROVAL_POLICIES.NEVER : undefined);
+
+    if (policy) {
+      args.push(
+        CLI.CODEX_FLAGS.CONFIG,
+        `${CLI.CODEX_CONFIG_KEYS.APPROVAL_POLICY}=${policy}`,
+      );
+    }
   }
 
   return executeCommand(CLI.COMMANDS.CODEX, args, context);

--- a/tests/utils/codexCapabilities.test.ts
+++ b/tests/utils/codexCapabilities.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../src/utils/commandExecutor.js', () => ({
+  executeCommand: vi.fn(),
+}));
+
+import { getCodexCapabilities, resetCodexCapabilitiesCache } from '../../src/utils/codexCapabilities.js';
+import { executeCommand } from '../../src/utils/commandExecutor.js';
+
+const MODERN_HELP = `
+Options:
+  -s, --sandbox <SANDBOX_MODE>
+      --approve-for-me
+          Route approval requests through automatic review using the workspace-write sandbox
+      --skip-git-repo-check
+`;
+
+const LEGACY_HELP = `
+Options:
+  -s, --sandbox <SANDBOX_MODE>
+  -a, --ask-for-approval <APPROVAL_POLICY>
+      --full-auto
+      --skip-git-repo-check
+`;
+
+describe('codexCapabilities', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetCodexCapabilitiesCache();
+  });
+
+  it('reports --approve-for-me support and no -a flag for modern codex', async () => {
+    vi.mocked(executeCommand).mockResolvedValue(MODERN_HELP);
+
+    const caps = await getCodexCapabilities();
+
+    expect(caps).toEqual({ approveForMe: true, askForApprovalFlag: false });
+  });
+
+  it('reports -a support and no --approve-for-me for legacy codex', async () => {
+    vi.mocked(executeCommand).mockResolvedValue(LEGACY_HELP);
+
+    const caps = await getCodexCapabilities();
+
+    expect(caps).toEqual({ approveForMe: false, askForApprovalFlag: true });
+  });
+
+  it('probes `codex exec --help` without streaming progress to the caller', async () => {
+    vi.mocked(executeCommand).mockResolvedValue(MODERN_HELP);
+    const onProgress = vi.fn();
+
+    await getCodexCapabilities({ onProgress });
+
+    const [command, args, options] = vi.mocked(executeCommand).mock.calls[0];
+    expect(command).toBe('codex');
+    expect(args).toEqual(['exec', '--help']);
+    expect(options?.onProgress).toBeUndefined();
+  });
+
+  it('probes the CLI only once per process', async () => {
+    vi.mocked(executeCommand).mockResolvedValue(MODERN_HELP);
+
+    await getCodexCapabilities();
+    await getCodexCapabilities();
+
+    expect(executeCommand).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to legacy flags when the probe fails', async () => {
+    vi.mocked(executeCommand).mockRejectedValue(new Error('codex not found'));
+
+    const caps = await getCodexCapabilities();
+
+    expect(caps).toEqual({ approveForMe: false, askForApprovalFlag: true });
+  });
+
+  it('retries the probe after a failure instead of caching the fallback', async () => {
+    vi.mocked(executeCommand).mockRejectedValueOnce(new Error('spawn failed'));
+    vi.mocked(executeCommand).mockResolvedValueOnce(MODERN_HELP);
+
+    const first = await getCodexCapabilities();
+    const second = await getCodexCapabilities();
+
+    expect(first.approveForMe).toBe(false);
+    expect(second.approveForMe).toBe(true);
+  });
+});

--- a/tests/utils/codexExecutor.test.ts
+++ b/tests/utils/codexExecutor.test.ts
@@ -4,59 +4,141 @@ vi.mock('../../src/utils/commandExecutor.js', () => ({
   executeCommand: vi.fn().mockResolvedValue('mock response'),
 }));
 
+vi.mock('../../src/utils/codexCapabilities.js', () => ({
+  getCodexCapabilities: vi.fn(),
+}));
+
 import { executeCodexCLI } from '../../src/utils/codexExecutor.js';
 import { executeCommand } from '../../src/utils/commandExecutor.js';
+import { getCodexCapabilities } from '../../src/utils/codexCapabilities.js';
+
+const MODERN = { approveForMe: true, askForApprovalFlag: false };
+const LEGACY = { approveForMe: false, askForApprovalFlag: true };
+
+function argsOfLastCall(): string[] {
+  return vi.mocked(executeCommand).mock.calls[0][1];
+}
 
 describe('codexExecutor', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(executeCommand).mockResolvedValue('mock response');
   });
 
-  it('builds correct base args', async () => {
-    await executeCodexCLI('fix this bug', 'gpt-5.2-codex');
+  describe('modern codex (--approve-for-me, no -a flag)', () => {
+    beforeEach(() => {
+      vi.mocked(getCodexCapabilities).mockResolvedValue(MODERN);
+    });
 
-    expect(executeCommand).toHaveBeenCalledWith(
-      'codex',
-      [
-        'exec', 'fix this bug',
-        '--full-auto',
-        '--skip-git-repo-check',
-        '--color', 'never',
-        '-m', 'gpt-5.2-codex',
-      ],
-      undefined
-    );
+    it('runs unattended with --approve-for-me when no sandbox is requested', async () => {
+      await executeCodexCLI('fix this bug', 'gpt-5.4');
+
+      expect(executeCommand).toHaveBeenCalledWith(
+        'codex',
+        [
+          'exec', 'fix this bug',
+          '--approve-for-me',
+          '--skip-git-repo-check',
+          '--color', 'never',
+          '-m', 'gpt-5.4',
+        ],
+        undefined
+      );
+    });
+
+    it('drops --approve-for-me when a sandbox is requested, since codex rejects both together', async () => {
+      await executeCodexCLI('task', 'gpt-5.4', 'read-only');
+
+      const args = argsOfLastCall();
+      expect(args).not.toContain('--approve-for-me');
+      expect(args).toContain('-s');
+      expect(args).toContain('read-only');
+    });
+
+    it('keeps a sandboxed run unattended by setting approval_policy=never', async () => {
+      await executeCodexCLI('task', 'gpt-5.4', 'workspace-write');
+
+      const args = argsOfLastCall();
+      expect(args).toContain('-c');
+      expect(args).toContain('approval_policy=never');
+    });
+
+    it('passes an explicit approvalPolicy as a config override instead of the removed -a flag', async () => {
+      await executeCodexCLI('task', 'gpt-5.4', undefined, 'on-request');
+
+      const args = argsOfLastCall();
+      expect(args).not.toContain('-a');
+      expect(args).toContain('-c');
+      expect(args).toContain('approval_policy=on-request');
+    });
+
+    it('honours an explicit approvalPolicy over the sandboxed default', async () => {
+      await executeCodexCLI('task', 'gpt-5.4', 'read-only', 'on-request');
+
+      const args = argsOfLastCall();
+      expect(args).toContain('approval_policy=on-request');
+      expect(args).not.toContain('approval_policy=never');
+    });
+
+    it('never emits --full-auto, which modern codex rejects', async () => {
+      await executeCodexCLI('task', 'gpt-5.4', 'read-only', 'never');
+
+      expect(argsOfLastCall()).not.toContain('--full-auto');
+    });
   });
 
-  it('adds -s sandbox when provided', async () => {
-    await executeCodexCLI('task', 'gpt-5.2-codex', 'read-only');
+  describe('legacy codex (--full-auto, -a flag)', () => {
+    beforeEach(() => {
+      vi.mocked(getCodexCapabilities).mockResolvedValue(LEGACY);
+    });
 
-    const args = vi.mocked(executeCommand).mock.calls[0][1];
-    expect(args).toContain('-s');
-    expect(args).toContain('read-only');
-  });
+    it('builds correct base args', async () => {
+      await executeCodexCLI('fix this bug', 'gpt-5.2-codex');
 
-  it('adds -a approvalPolicy when provided', async () => {
-    await executeCodexCLI('task', 'gpt-5.2-codex', undefined, 'never');
+      expect(executeCommand).toHaveBeenCalledWith(
+        'codex',
+        [
+          'exec', 'fix this bug',
+          '--full-auto',
+          '--skip-git-repo-check',
+          '--color', 'never',
+          '-m', 'gpt-5.2-codex',
+        ],
+        undefined
+      );
+    });
 
-    const args = vi.mocked(executeCommand).mock.calls[0][1];
-    expect(args).toContain('-a');
-    expect(args).toContain('never');
-  });
+    it('adds -s sandbox when provided', async () => {
+      await executeCodexCLI('task', 'gpt-5.2-codex', 'read-only');
 
-  it('includes both sandbox and approvalPolicy when both provided', async () => {
-    await executeCodexCLI('task', 'gpt-5.2-codex', 'workspace-write', 'on-failure');
+      const args = argsOfLastCall();
+      expect(args).toContain('-s');
+      expect(args).toContain('read-only');
+    });
 
-    const args = vi.mocked(executeCommand).mock.calls[0][1];
-    expect(args).toContain('-s');
-    expect(args).toContain('workspace-write');
-    expect(args).toContain('-a');
-    expect(args).toContain('on-failure');
+    it('adds -a approvalPolicy when provided', async () => {
+      await executeCodexCLI('task', 'gpt-5.2-codex', undefined, 'never');
+
+      const args = argsOfLastCall();
+      expect(args).toContain('-a');
+      expect(args).toContain('never');
+    });
+
+    it('includes both sandbox and approvalPolicy when both provided', async () => {
+      await executeCodexCLI('task', 'gpt-5.2-codex', 'workspace-write', 'on-failure');
+
+      const args = argsOfLastCall();
+      expect(args).toContain('-s');
+      expect(args).toContain('workspace-write');
+      expect(args).toContain('-a');
+      expect(args).toContain('on-failure');
+    });
   });
 
   it('passes onProgress callback through', async () => {
+    vi.mocked(getCodexCapabilities).mockResolvedValue(MODERN);
     const onProgress = vi.fn();
-    await executeCodexCLI('task', 'gpt-5.2-codex', undefined, undefined, { onProgress });
+    await executeCodexCLI('task', 'gpt-5.4', undefined, undefined, { onProgress });
 
     expect(executeCommand).toHaveBeenCalledWith(
       'codex',


### PR DESCRIPTION
## Problem

`codex exec` dropped `--full-auto` and `-a/--ask-for-approval` in newer releases. Verified against codex-cli 0.147.0:

    error: unexpected argument '--full-auto' found

`executeCodexCLI` always sends `--full-auto`, so **every `Ask-Codex` call fails immediately** on a recent Codex CLI — both for the published package and for a locally built server.

## Approach

Version numbers don't reliably say when the flags went away, so this asks the CLI instead: `codex exec --help` is probed once per process (cached) and the args are built from what the installed CLI actually supports.

| installed CLI | unattended run | explicit `approvalPolicy` |
| --- | --- | --- |
| modern | `--approve-for-me` | `-c approval_policy=<value>` |
| legacy | `--full-auto` (unchanged) | `-a <value>` (unchanged) |

Two constraints found while verifying against 0.147.0:

- `--approve-for-me` is **mutually exclusive** with `-s/--sandbox` (`error: the argument '--approve-for-me' cannot be used with '--sandbox <SANDBOX_MODE>'`). When a sandbox is requested the flag is dropped and `-c approval_policy=never` keeps the run unattended.
- `approval_policy` still accepts `untrusted | on-failure | on-request | granular | never`, so every value in the `Ask-Codex` schema round-trips through the config override.

If the probe fails, it falls back to the legacy flags, and that failure is **not** cached — a transient spawn error must not pin legacy behaviour for the rest of the process.

## Test plan
- [x] `npm test` (relevant) green — 17 unit tests across `codexCapabilities` + `codexExecutor`, covering the modern and legacy flag paths
- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] Full `npm test` baseline regression — the same 10 pre-existing environment failures before and after (POSIX path assertions + process-tree kill, Windows-only)
- [x] Live E2E on Windows 11 / Node v24.15.0 / codex-cli 0.147.0 — against the built `dist/`, both the default path (`--approve-for-me`) and the sandboxed path (`-s read-only` + `-c approval_policy=never`) return the expected response
- [x] Probe verified live: `{"approveForMe":true,"askForApprovalFlag":false}`

> Out of scope for this PR (tracked as follow-up, not a merge blocker): the exact upstream release that removed `--full-auto` is not pinned down — capability probing makes the version boundary irrelevant, and the legacy path stays covered by unit tests. Also, the `approvalPolicy` enum in `ask-codex.tool.ts` is left unchanged, since all of its values are still valid `approval_policy` values on 0.147.0.
